### PR TITLE
test: 💍 workaround for hook calling in onClick

### DIFF
--- a/src/components/nav_bar/nav_bar.tsx
+++ b/src/components/nav_bar/nav_bar.tsx
@@ -69,9 +69,8 @@ const NavBar = () => {
 
   const logOutClickHandler = async () => {
     setIsUserMenuOpen(false);
-
+    setShouldFetch(true);
     console.log(`onClick logOutClickHandler`);
-
     console.log(`response: `, response);
   };
 

--- a/src/components/nav_bar/nav_bar.tsx
+++ b/src/components/nav_bar/nav_bar.tsx
@@ -21,6 +21,17 @@ import useAPI from '@/lib/hooks/use_api';
 const NavBar = () => {
   const { credential: credential, signedIn, username } = useUserCtx();
 
+  const [shouldFetch, setShouldFetch] = React.useState<boolean>(false);
+  const response = useAPI<IUserAuth>(
+    shouldFetch ? APIName.SIGN_OUT : null,
+
+    // `${shouldFetch} ? ${APIName.SIGN_OUT} : null`,
+    {
+      body: { credential },
+    },
+    false
+  );
+
   const burgerButtonStyle =
     'h-2px rounded-full bg-button-text-secondary transition-all duration-150 ease-in-out';
 
@@ -60,13 +71,7 @@ const NavBar = () => {
     setIsUserMenuOpen(false);
 
     console.log(`onClick logOutClickHandler`);
-    const response = useAPI<IUserAuth>(
-      APIName.SIGN_OUT,
-      {
-        body: { credential },
-      },
-      false
-    );
+
     console.log(`response: `, response);
   };
 

--- a/src/lib/hooks/use_api.ts
+++ b/src/lib/hooks/use_api.ts
@@ -80,7 +80,7 @@ const useAPI = <Data>(
     } finally {
       setIsLoading(false);
     }
-  }, [apiConfig.method, options, path, handleError]);
+  }, [apiConfig.method, options, path]);
 
   console.log(
     'useAPI is called, apiConfig',

--- a/src/lib/hooks/use_api.ts
+++ b/src/lib/hooks/use_api.ts
@@ -39,13 +39,25 @@ async function fetchData<Data>(
   return response.json();
 }
 
-const useAPI = <Data>(apiName: APIName, options: IAPIInput, cancel?: boolean): Response<Data> => {
+const useAPI = <Data>(
+  apiName: APIName | null,
+  options: IAPIInput,
+  cancel?: boolean
+): Response<Data> => {
   const [data, setData] = useState<Data | undefined>(undefined);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<Error | null>(null);
   const [message, setMessage] = useState<string | undefined>(undefined);
 
-  const apiConfig = APIConfig[apiName];
+  if (!apiName) {
+    return {
+      isLoading: false,
+      data: undefined,
+      message: undefined,
+      error: null,
+    };
+  }
+  const apiConfig = APIConfig[apiName] ?? {};
   console.log('useAPI is called, apiConfig', apiConfig, `options`, options, `cancel`, cancel);
   checkInput(apiConfig, options);
 


### PR DESCRIPTION
- 單純 hook 不能在 function 裡面被呼叫，也不能在 onClick 呼叫，[test: 💍 workaround for hook calling in onClick](https://github.com/CAFECA-IO/iSunFA/pull/521/files) 可以繞過這個限制，但會增加使用複雜度
- 查找之後發現兩個解決方法：
    - 使用此 PR 的方式在 onclick 的時候呼叫 API
    - 實作另一個方法在 onclick 的時候呼叫 API ，可能的實作方法之一： [swr lib](https://swr.vercel.app/docs/mutation#useswrmutation)
- 另外，在成功使用 useAPI hook 之後，會因為其他錯誤導致網頁 crash ， 可能是在 useAPI 裡 exception 沒有被接住


![image](https://github.com/CAFECA-IO/iSunFA/assets/20677913/8278718e-3cc1-4115-b510-86ee6cd9a6e5)

![image](https://github.com/CAFECA-IO/iSunFA/assets/20677913/8f9bf0de-12a8-49fd-9b4c-cc31cdb63b60)



