### PR TITLE
feat: update api connection and api worker to parse header

### DIFF
--- a/src/components/create_company_modal/create_company_modal.tsx
+++ b/src/components/create_company_modal/create_company_modal.tsx
@@ -49,16 +49,7 @@ const CreateCompanyModal = ({ isModalVisible, modalVisibilityHandler }: ICreateC
     success: createCompanySuccess,
     error: createCompanyError,
     code: createCompanyCode,
-  } = APIHandler<ICompany>(
-    APIName.COMPANY_ADD,
-    {
-      header: {
-        userid: username ?? DEFAULT_DISPLAYED_USER_NAME,
-      },
-    },
-    false,
-    false
-  );
+  } = APIHandler<ICompany>(APIName.COMPANY_ADD, {}, false, false);
 
   const [nameValue, setNameValue] = useState<string>('');
   const [registrationNumberValue, setRegistrationNumberValue] = useState<string>('');
@@ -178,6 +169,9 @@ const CreateCompanyModal = ({ isModalVisible, modalVisibilityHandler }: ICreateC
     event.preventDefault();
 
     createCompany({
+      header: {
+        userid: username ?? DEFAULT_DISPLAYED_USER_NAME,
+      },
       body: {
         name: nameValue,
         code: registrationNumberValue,

--- a/src/constants/api_connection.ts
+++ b/src/constants/api_connection.ts
@@ -360,7 +360,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   USER_UPDATE: {
     name: APIName.USER_UPDATE,
     method: HttpMethod.PUT,
-    path: '',
+    path: APIPath.USER_UPDATE,
     input: {
        header: {},
       body: {},
@@ -373,7 +373,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   COMPANY_LIST: {
     name: APIName.COMPANY_LIST,
     method: HttpMethod.GET,
-    path: '',
+    path: APIPath.COMPANY_LIST,
     input: {
        header: {},
       body: {},
@@ -386,7 +386,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   COMPANY_ADD: {
     name: APIName.COMPANY_ADD,
     method: HttpMethod.POST,
-    path: '',
+    path: APIPath.COMPANY_ADD,
     input: {
        header: {},
       body: {},
@@ -399,7 +399,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   COMPANY_ADD_BY_INVITATION_CODE: {
     name: APIName.COMPANY_ADD_BY_INVITATION_CODE,
     method: HttpMethod.POST,
-    path: '',
+    path: APIPath.COMPANY_ADD_BY_INVITATION_CODE,
     input: {
        header: {},
       body: {},
@@ -412,7 +412,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   PROFIT_GET_INSIGHT: {
     name: APIName.PROFIT_GET_INSIGHT,
     method: HttpMethod.GET,
-    path: '',
+    path: APIPath.PROFIT_GET_INSIGHT,
     input: {
        header: {},
       body: {},
@@ -425,7 +425,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   PROFIT_GET_TREND_IN_PERIOD: {
     name: APIName.PROFIT_GET_TREND_IN_PERIOD,
     method: HttpMethod.GET,
-    path: '',
+    path: APIPath.PROFIT_GET_TREND_IN_PERIOD,
     input: {
        header: {},
       body: {},
@@ -438,7 +438,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   PROFIT_GET_MARGIN_TREND_IN_PERIOD: {
     name: APIName.PROFIT_GET_MARGIN_TREND_IN_PERIOD,
     method: HttpMethod.GET,
-    path: '',
+    path: APIPath.PROFIT_GET_MARGIN_TREND_IN_PERIOD,
     input: {
        header: {},
       body: {},
@@ -451,7 +451,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   PROJECT_LIST_PROGRESS: {
     name: APIName.PROJECT_LIST_PROGRESS,
     method: HttpMethod.GET,
-    path: '',
+    path: APIPath.PROJECT_LIST_PROGRESS,
     input: {
        header: {},
       body: {},
@@ -464,7 +464,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   PROJECT_LIST_PROFIT_COMPARISON: {
     name: APIName.PROJECT_LIST_PROFIT_COMPARISON,
     method: HttpMethod.GET,
-    path: '',
+    path: APIPath.PROJECT_LIST_PROFIT_COMPARISON,
     input: {
        header: {},
       body: {},
@@ -477,7 +477,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   INVOCIE_LIST_UNBOUNDED: {
     name: APIName.INVOCIE_LIST_UNBOUNDED,
     method: HttpMethod.GET,
-    path: '',
+    path: APIPath.INVOCIE_LIST_UNBOUNDED,
     input: {
        header: {},
       body: {},
@@ -490,7 +490,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   ASSET_MANAGEMENT_LIST: {
     name: APIName.ASSET_MANAGEMENT_LIST,
     method: HttpMethod.GET,
-    path: '',
+    path: APIPath.ASSET_MANAGEMENT_LIST,
     input: {
        header: {},
       body: {},
@@ -503,7 +503,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   ASSET_MANAGEMENT_ADD: {
     name: APIName.ASSET_MANAGEMENT_ADD,
     method: HttpMethod.POST,
-    path: '',
+    path: APIPath.ASSET_MANAGEMENT_ADD,
     input: {
        header: {},
       body: {},
@@ -516,7 +516,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   ASSET_MANAGEMENT_GET_BY_ID: {
     name: APIName.ASSET_MANAGEMENT_GET_BY_ID,
     method: HttpMethod.GET,
-    path: '',
+    path: APIPath.ASSET_MANAGEMENT_GET_BY_ID,
     input: {
        header: {},
       body: {},
@@ -529,7 +529,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   ASSET_MANAGEMENT_UPDATE: {
     name: APIName.ASSET_MANAGEMENT_UPDATE,
     method: HttpMethod.PUT,
-    path: '',
+    path: APIPath.ASSET_MANAGEMENT_UPDATE,
     input: {
        header: {},
       body: {},
@@ -542,7 +542,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   JOURNAL_UPDATE: {
     name: APIName.JOURNAL_UPDATE,
     method: HttpMethod.PUT,
-    path: '',
+    path: APIPath.JOURNAL_UPDATE,
     input: {
        header: {},
       body: {},
@@ -555,7 +555,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   JOURNAL_DELETE: {
     name: APIName.JOURNAL_DELETE,
     method: HttpMethod.DELETE,
-    path: '',
+    path: APIPath.JOURNAL_DELETE,
     input: {
        header: {},
       body: {},
@@ -568,7 +568,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   JOURNAL_LIST_PROGRESS_STATUS: {
     name: APIName.JOURNAL_LIST_PROGRESS_STATUS,
     method: HttpMethod.GET,
-    path: '',
+    path: APIPath.JOURNAL_LIST_PROGRESS_STATUS,
     input: {
        header: {},
       body: {},
@@ -581,7 +581,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   FINANCIAL_REPORT_LIST: {
     name: APIName.FINANCIAL_REPORT_LIST,
     method: HttpMethod.GET,
-    path: '',
+    path: APIPath.FINANCIAL_REPORT_LIST,
     input: {
        header: {},
       body: {},
@@ -594,7 +594,7 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
   ANALYSIS_REPORT_LIST: {
     name: APIName.ANALYSIS_REPORT_LIST,
     method: HttpMethod.GET,
-    path: '',
+    path: APIPath.ANALYSIS_REPORT_LIST,
     input: {
        header: {},
       body: {},

--- a/src/lib/hooks/use_api.ts
+++ b/src/lib/hooks/use_api.ts
@@ -40,7 +40,7 @@ export async function fetchData<Data>(
 
   // Deprecated: debug log (20240510 - Tzuahan)
   // eslint-disable-next-line no-console
-  console.log(`fetchData(${apiConfig.name}), path:`, path, `options:`, options, apiConfig);
+  console.log(`fetchData(${apiConfig.name}), path:`, path, `options:`, options, `apiConfig:`, apiConfig);
 
   if (apiConfig.method !== HttpMethod.GET && options.body) {
     if (options.body instanceof FormData) {
@@ -89,6 +89,7 @@ const useAPI = <Data>(
           apiConfig,
           {
             ...options,
+            header: input?.header || options.header,
             params: input?.params || options.params,
             query: input?.query || options.query,
             body: input?.body || options.body,

--- a/src/lib/hooks/use_api_worker.ts
+++ b/src/lib/hooks/use_api_worker.ts
@@ -46,6 +46,7 @@ const useAPIWorker = <Data>(
       apiConfig,
       options: {
         ...options,
+        header: input?.header || options.header,
         params: input?.params || options.params,
         query: input?.query || options.query,
         body: input?.body || options.body,


### PR DESCRIPTION
### DEVELOP
- 修復 #751 遇到的錯誤
    - APIConfig 裡面的 Path 補齊缺漏
    - APIHandler 沒有處理傳進 function 的 header
        - POST api/v1/company 不應該檢查 headers 中的 userid，應該透過 cookie 裡面的 fido2 相關參數到 DB 找到對應的 user
### CHECK LIST
- [Naming convention](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md) verification: checked
- Coding style verification: checked
- new Library: 
- new Class / Component: 
 - new loop: 0
- new recursive: 0
- high risk: 0
- new sql: 0