### PR TITLE
fix: the side effect of change of the report type for date picker on financial applying page and recover the reports to A4 height and hide report thumbnails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iSunFA",
-  "version": "0.1.8+132",
+  "version": "0.1.8+134",
   "private": false,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iSunFA",
-  "version": "0.1.8+130",
+  "version": "0.1.8+132",
   "private": false,
   "scripts": {
     "dev": "next dev",

--- a/src/components/balance_sheet_report_body/balance_sheet_report_body_all.tsx
+++ b/src/components/balance_sheet_report_body/balance_sheet_report_body_all.tsx
@@ -1382,7 +1382,7 @@ const BalanceSheetReportBodyAll = ({ reportId }: IBalanceSheetReportBodyAllProps
   );
 
   return (
-    <div className="scale-80 mx-auto w-a4-width origin-top overflow-x-auto md:scale-100 lg:scale-100">
+    <div className="mx-auto w-a4-width origin-top overflow-x-auto">
       {page1}
       <hr className="break-before-page" />
       {page2}

--- a/src/components/cash_flow_statement_report_body/cash_flow_statement_report_body_all.tsx
+++ b/src/components/cash_flow_statement_report_body/cash_flow_statement_report_body_all.tsx
@@ -864,7 +864,7 @@ const CashFlowStatementReportBodyAll = ({ reportId }: ICashFlowStatementReportBo
   );
 
   return (
-    <div className="mx-auto w-a4-width origin-top scale-80 overflow-x-auto md:scale-100 lg:scale-100">
+    <div className="mx-auto w-a4-width origin-top overflow-x-auto">
       {page1}
       {page2}
       {page3}

--- a/src/components/date_picker/date_picker.tsx
+++ b/src/components/date_picker/date_picker.tsx
@@ -219,11 +219,33 @@ const DatePicker = ({
   const [selectedMonth, setSelectedMonth] = useState(today.getMonth() + 1); // 0 (January) to 11 (December).
   const [selectedYear, setSelectedYear] = useState(today.getFullYear());
 
+  // useEffect(() => {
+  //   setDateOne(new Date(period.startTimeStamp * MILLISECONDS_IN_A_SECOND));
+  //   setDateTwo(new Date(period.endTimeStamp * MILLISECONDS_IN_A_SECOND));
+  // }, [period]);
+
   useEffect(() => {
     // Info: (20240417 - Shirley) 如果已取得兩個日期，則將日期區間傳回父層
     // Info: (20240417 - Shirley) 如果兩個日期相同，則將日期區間設為當天 00:00:00 ~ 23:59:59
-    const dateOneStamp = dateOne ? dateOne.getTime() / MILLISECONDS_IN_A_SECOND : 0;
-    const dateTwoStamp = dateTwo ? dateTwo.getTime() / MILLISECONDS_IN_A_SECOND : 0;
+    let dateOneStamp = 0;
+    let dateTwoStamp = 0;
+    if (type === DatePickerType.ICON_PERIOD || type === DatePickerType.TEXT_PERIOD) {
+      dateOneStamp = dateOne ? dateOne.getTime() / MILLISECONDS_IN_A_SECOND : 0;
+      dateTwoStamp = dateTwo ? dateTwo.getTime() / MILLISECONDS_IN_A_SECOND : 0;
+    } else {
+      dateOneStamp = dateOne ? dateOne.getTime() / MILLISECONDS_IN_A_SECOND : 0;
+      dateTwoStamp = dateOne ? dateOne.getTime() / MILLISECONDS_IN_A_SECOND : 0;
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(
+      'type in DatePicker',
+      type,
+      'dateOneStamp',
+      dateOneStamp,
+      'dateTwoStamp',
+      dateTwoStamp
+    );
 
     if (dateOneStamp && dateTwoStamp) {
       const isSameDate = dateOneStamp === dateTwoStamp;
@@ -258,19 +280,7 @@ const DatePicker = ({
         endTimeStamp: 0,
       });
     }
-  }, [dateOne, dateTwo]);
-
-  // TODO: 在不讓 parent component re-render 造成多次 API call 的情況下，將 period 從一段期間改成一個日期 (20240527 - Shirley)
-  // Info: If type changed, reset the date (20240425 - Shirley)
-  // useEffect(() => {
-  //   if (type === DatePickerType.CHOOSE_PERIOD || type === DatePickerType.ICON) {
-  //     setDateOne(new Date(period.startTimeStamp * MILLISECONDS_IN_A_SECOND));
-  //     setDateTwo(new Date(period.endTimeStamp * MILLISECONDS_IN_A_SECOND));
-  //   } else {
-  //     setDateOne(new Date(period.startTimeStamp * MILLISECONDS_IN_A_SECOND));
-  //     setDateTwo(new Date(period.startTimeStamp * MILLISECONDS_IN_A_SECOND));
-  //   }
-  // }, [type]);
+  }, [dateOne, dateTwo, type]);
 
   // Info: (20240417 - Shirley) 取得該月份第一天是星期幾
   const firstDayOfMonth = (year: number, month: number) => {

--- a/src/components/date_picker/date_picker.tsx
+++ b/src/components/date_picker/date_picker.tsx
@@ -237,16 +237,6 @@ const DatePicker = ({
       dateTwoStamp = dateOne ? dateOne.getTime() / MILLISECONDS_IN_A_SECOND : 0;
     }
 
-    // eslint-disable-next-line no-console
-    console.log(
-      'type in DatePicker',
-      type,
-      'dateOneStamp',
-      dateOneStamp,
-      'dateTwoStamp',
-      dateTwoStamp
-    );
-
     if (dateOneStamp && dateTwoStamp) {
       const isSameDate = dateOneStamp === dateTwoStamp;
       setFilteredPeriod({

--- a/src/components/financial_report_section/financial_report_section.tsx
+++ b/src/components/financial_report_section/financial_report_section.tsx
@@ -115,13 +115,14 @@ const FinancialReportSection = () => {
   useEffect(() => {
     setDatePickerType(() => {
       if (selectedReportType === FinancialReportTypesKey.balance_sheet) {
+        setPeriod(default30DayPeriodInSec);
         return DatePickerType.TEXT_DATE;
       } else {
+        setPeriod(default30DayPeriodInSec);
         return DatePickerType.TEXT_PERIOD;
       }
     });
   }, [selectedReportType]);
-
   useEffect(() => {
     // Info: 每次展開 menu 之前都要清空 searchQuery (20240509 - Shirley)
     if (isProjectMenuOpen) {
@@ -135,9 +136,6 @@ const FinancialReportSection = () => {
       if (generatedSuccess) {
         messageModalDataHandler({
           title: '',
-          // subtitle: 'We received your application',
-          // content: `It will take 30 to 40 minutes for the AI to generate the report, you can comeback and check it later.`,
-          // submitBtnStr: 'Close',
           subtitle: t('MY_REPORTS_SECTION.WE_RECEIVED_YOUR_APPLICATION'),
           content: t('MY_REPORTS_SECTION.TAKE_MINUTES'),
           submitBtnStr: t('COMMON.CLOSE'),
@@ -592,7 +590,7 @@ const FinancialReportSection = () => {
           </div>
           <div className="mt-6 flex flex-col justify-center">
             <DatePicker
-              // key={selectedReportType}  // Info: if we want to update the DatePicker whether the DatePickerType is changed or not, uncomment the below (20240425 - Shirley)
+              key={`${selectedReportType}-${period.startTimeStamp}-${period.endTimeStamp}`}
               type={datePickerType}
               period={period}
               setFilteredPeriod={setPeriod}

--- a/src/components/income_statement_report_body/income_statement_report_body_all.tsx
+++ b/src/components/income_statement_report_body/income_statement_report_body_all.tsx
@@ -1193,7 +1193,7 @@ const IncomeStatementReportBodyAll = ({ reportId }: IIncomeStatementReportBodyAl
   );
 
   return (
-    <div className="mx-auto w-a4-width origin-top scale-80 overflow-x-auto md:scale-100 lg:scale-100">
+    <div className="mx-auto w-a4-width origin-top overflow-x-auto">
       {page1}
       <hr className="break-before-page" />
       {page2}

--- a/src/components/view_financial_section/view_financial_section.tsx
+++ b/src/components/view_financial_section/view_financial_section.tsx
@@ -322,10 +322,10 @@ const ViewFinancialSection = ({
       <div className="hidden w-1/4 overflow-y-scroll bg-white pl-0 lg:flex">
         <div className="mt-9 flex w-full flex-col items-center justify-center">
           <div className="flex h-850px flex-col gap-3">
-            {!isLoading ? (
-              reportThumbnails.map((thumbnail, index) => renderedThumbnail(thumbnail, index))
-            ) : (
+            {isLoading ? (
               <p>{t('MY_REPORTS_SECTION.LOADING')}</p>
+            ) : isInvalidReport ? null : (
+              reportThumbnails.map((thumbnail, index) => renderedThumbnail(thumbnail, index))
             )}
           </div>
         </div>

--- a/src/pages/users/reports/financials/index.tsx
+++ b/src/pages/users/reports/financials/index.tsx
@@ -34,7 +34,6 @@ const FinancialsReportsPage = () => {
         <meta charSet="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon/favicon.ico" />
-        {/* TODO: i18n (20240409 - Shirley) */}
         <title>{t('REPORTS_SIDEBAR.FINANCIAL_REPORT')}</title>
         <meta
           name="description"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,6 +5,7 @@ module.exports = {
     extend: {
       scale: {
         80: '0.8',
+        90: '0.9',
       },
       aspectRatio: {
         '1/1': '1 / 1',


### PR DESCRIPTION
### DEVELOP

- [X] fix: the side effect of change of the report type for date picker on financial applying page
- [X] refactor: recover the reports to A4 height
- [X] refactor: hide the thumbnails for reports when API data formats are invalid

#### Related Issues

- [X] Issue Number:  #1855

#### Checklist

- [x] Used `@` in import paths.
- [x] Verified naming convention compliance ([Naming Convention Guidelines](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md)).
- [x] Coding style verification: checked
- [x] new Library: 0
- [x] new Class / Component: 0
- [x] new loop: 0
- [x] new recursive: 0
- [x] high risk: 0
- [x] new sql: 0

#### UML Diagrams

- None

#### Additional Notes

- Ensured all links are up-to-date.
- Conducted thorough testing on responsive design changes.
- Documented any notable considerations or edge cases addressed.