### PR TITLE
feat: call the get-public-key api on add-journal page when company id is got

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iSunFA",
-  "version": "0.8.0+42",
+  "version": "0.8.0+43",
   "private": false,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iSunFA",
-  "version": "0.8.0+43",
+  "version": "0.8.0+44",
   "private": false,
   "scripts": {
     "dev": "next dev",

--- a/src/components/journal_upload_area/journal_upload_area.tsx
+++ b/src/components/journal_upload_area/journal_upload_area.tsx
@@ -318,11 +318,6 @@ const JournalUploadArea = () => {
                   : 'border-drag-n-drop-stroke-primary bg-drag-n-drop-surface-primary',
               ]
         )}
-        // className={`flex h-full w-full flex-col rounded-lg border border-dashed hover:cursor-pointer ${
-        //   isDragOver
-        //     ? 'border-drag-n-drop-stroke-focus bg-drag-n-drop-surface-hover'
-        //     : 'border-drag-n-drop-stroke-primary bg-drag-n-drop-surface-primary'
-        // } ${isUploadDisabled ? 'cursor-not-allowed border-button-stroke-disable bg-button-surface-soft-disable' : 'hover:border-drag-n-drop-stroke-focus hover:bg-drag-n-drop-surface-hover'} items-center justify-center p-24px md:p-48px`}
       >
         <Image src="/icons/upload_file.svg" width={55} height={60} alt="upload_file" />
         <p className="mt-20px font-semibold text-navyBlue2">

--- a/src/components/journal_upload_area/journal_upload_area.tsx
+++ b/src/components/journal_upload_area/journal_upload_area.tsx
@@ -41,11 +41,11 @@ const JournalUploadArea = () => {
     code: uploadCode,
   } = APIHandler<IOCR[]>(APIName.OCR_UPLOAD);
 
-  const { data: publicKeyData, success: fetchPublicKeySuccess } = APIHandler<JsonWebKey>(
-    APIName.PUBLIC_KEY_GET,
-    { params: { companyId: selectedCompany?.id } },
-    true
-  );
+  const {
+    trigger: fetchPublicKey,
+    data: publicKeyData,
+    success: fetchPublicKeySuccess,
+  } = APIHandler<JsonWebKey>(APIName.PUBLIC_KEY_GET);
 
   // Info: (20240711 - Julian) 上傳的檔案
   const [uploadFile, setUploadFile] = useState<FileInfo | null>(null);
@@ -183,6 +183,12 @@ const JournalUploadArea = () => {
 
     uploadInvoice({ params: { companyId }, body: formData });
   };
+
+  useEffect(() => {
+    if (selectedCompany?.id) {
+      fetchPublicKey({ params: { companyId: selectedCompany.id } });
+    }
+  }, [selectedCompany?.id]);
 
   useEffect(() => {
     if (!selectedCompany?.id || pendingOCRListFromBrowser.length === 0) return;

--- a/src/constants/api_connection.ts
+++ b/src/constants/api_connection.ts
@@ -80,6 +80,7 @@ export enum APIName {
   CREATE_PROJECT = 'CREATE_PROJECT',
   GET_PROJECT_BY_ID = 'GET_PROJECT_BY_ID',
   UPDATE_PROJECT_BY_ID = 'UPDATE_PROJECT_BY_ID',
+  PUBLIC_KEY_GET = 'PUBLIC_KEY_GET',
 }
 
 export enum APIPath {
@@ -143,6 +144,7 @@ export enum APIPath {
   CREATE_PROJECT = `${apiPrefix}/company/:companyId/project`,
   GET_PROJECT_BY_ID = `${apiPrefix}/company/:companyId/project/:projectId`,
   UPDATE_PROJECT_BY_ID = `${apiPrefix}/company/:companyId/project/:projectId`,
+  PUBLIC_KEY_GET = `${apiPrefix}/company/:companyId/public_key`,
 }
 const createConfig = ({
   name,
@@ -468,5 +470,10 @@ export const APIConfig: Record<IAPIName, IAPIConfig> = {
     name: APIName.UPDATE_PROJECT_BY_ID,
     method: HttpMethod.PUT,
     path: APIPath.UPDATE_PROJECT_BY_ID,
+  }),
+  [APIName.PUBLIC_KEY_GET]: createConfig({
+    name: APIName.PUBLIC_KEY_GET,
+    method: HttpMethod.GET,
+    path: APIPath.PUBLIC_KEY_GET,
   }),
 };

--- a/src/interfaces/api_connection.ts
+++ b/src/interfaces/api_connection.ts
@@ -61,7 +61,8 @@ export type IAPIName =
   | 'PROJECT_LIST'
   | 'CREATE_PROJECT'
   | 'GET_PROJECT_BY_ID'
-  | 'UPDATE_PROJECT_BY_ID';
+  | 'UPDATE_PROJECT_BY_ID'
+  | 'PUBLIC_KEY_GET';
 
 export type IHttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD';
 

--- a/src/locales/cn/common.json
+++ b/src/locales/cn/common.json
@@ -442,7 +442,9 @@
     "DATE_HINT": "请选择日期",
     "AMOUNT_HINT": "请填入金额",
     "TIMES_HINT": "请填入次数",
-    "INCONSISTENT_COMPANY_ID": "公司 ID 不一致"
+    "INCONSISTENT_COMPANY_ID": "公司 ID 不一致",
+    "FAILED_TO_FETCH_PUBLIC_KEY": "获取公钥失败",
+    "FAILED_TO_UPLOAD_FILE": "上传文件失败"
   },
   "PROJECT": {
     "CHOOSE_TEAM_MEMBERS": "选择团队成员",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -442,7 +442,9 @@
     "DATE_HINT": "Please select date",
     "AMOUNT_HINT": "Please fill in amount",
     "TIMES_HINT": "Please fill in times",
-    "INCONSISTENT_COMPANY_ID": "Inconsistent companyId"
+    "INCONSISTENT_COMPANY_ID": "Inconsistent companyId",
+    "FAILED_TO_FETCH_PUBLIC_KEY": "Failed to fetch public key",
+    "FAILED_TO_UPLOAD_FILE": "Failed to upload file"
   },
   "PROJECT": {
     "CHOOSE_TEAM_MEMBERS": "Choose Team Members",

--- a/src/locales/tw/common.json
+++ b/src/locales/tw/common.json
@@ -442,7 +442,9 @@
     "DATE_HINT": "請選擇日期",
     "AMOUNT_HINT": "請填入金額",
     "TIMES_HINT": "請填入次數",
-    "INCONSISTENT_COMPANY_ID": "公司 ID 不一致"
+    "INCONSISTENT_COMPANY_ID": "公司 ID 不一致",
+    "FAILED_TO_FETCH_PUBLIC_KEY": "獲取公鑰失敗",
+    "FAILED_TO_UPLOAD_FILE": "上傳文件失敗"
   },
   "PROJECT": {
     "CHOOSE_TEAM_MEMBERS": "選擇團隊成員",


### PR DESCRIPTION
### DEVELOP

- feat: integrate the get-public-key api on add-journal page when render the page
- feat: restrict uploading and show the relevant alerts when get-public-key fails
  
#### Related Issues

- [X] Issue Number: #2189

#### Checklist

- [x] Used `@` in import paths.
- [x] Verified naming convention compliance ([Naming Convention Guidelines](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md)).
- [x] Coding style verification: checked
- [x] new Library: 0
- [x] new Class / Component: 0
- [x] new loop: 0
- [x] new recursive: 0
- [x] high risk: 0
- [x] new sql: 0

#### UML Diagrams

- None

#### Additional Notes

- Ensured all links are up-to-date.
- Conducted thorough testing on responsive design changes.
- Documented any notable considerations or edge cases addressed.