### PR TITLE
Feature/beta voucher bug v3

### DIFF
--- a/src/components/voucher/voucher_detail_page_body.tsx
+++ b/src/components/voucher/voucher_detail_page_body.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { useTranslation } from 'next-i18next';
+import { useTranslation, Trans } from 'next-i18next';
 import { FiTrash2, FiEdit, FiBookOpen } from 'react-icons/fi';
 import { MdOutlineFileDownload } from 'react-icons/md';
 import { ICertificateUI } from '@/interfaces/certificate';
@@ -234,17 +234,21 @@ const VoucherDetailPageBody: React.FC<IVoucherDetailPageBodyProps> = ({ voucherI
       {note && <p className="text-input-text-primary">{note}</p>}
       {deletedReverseVoucherIds.length > 0 &&
         deletedReverseVoucherIds.map((deletedReverseVoucherId) => (
-          <p className="text-text-neutral-tertiary">
-            {t('journal:VOUCHER_DETAIL_PAGE.DELETED_REVERSE_VOUCHER', {
-              voucherNo: (
-                <Link
-                  href={`/users/accounting/${deletedReverseVoucherId.id}?voucherNo=${deletedReverseVoucherId.voucherNo}`}
-                  className="text-link-text-primary hover:underline"
-                >
-                  {deletedReverseVoucherId.voucherNo}
-                </Link>
-              ),
-            })}
+          <p className="text-input-text-primary">
+            <Trans
+              i18nKey="journal:VOUCHER_DETAIL_PAGE.DELETED_REVERSE_VOUCHER"
+              values={{ voucherNo: deletedReverseVoucherId.voucherNo }}
+              components={{
+                link: (
+                  <Link
+                    href={`/users/accounting/${deletedReverseVoucherId.id}?voucherNo=${deletedReverseVoucherId.voucherNo}`}
+                    className="text-link-text-primary hover:underline"
+                  >
+                    {deletedReverseVoucherId.voucherNo}
+                  </Link>
+                ),
+              }}
+            />
           </p>
         ))}
       {!note && deletedReverseVoucherIds.length === 0 && (

--- a/src/components/voucher/voucher_detail_page_body.tsx
+++ b/src/components/voucher/voucher_detail_page_body.tsx
@@ -28,7 +28,7 @@ interface IVoucherDetailPageBodyProps {
 }
 
 const VoucherDetailPageBody: React.FC<IVoucherDetailPageBodyProps> = ({ voucherId, voucherNo }) => {
-  const { t } = useTranslation('common');
+  const { t } = useTranslation(['common', 'journal']);
   const router = useRouter();
   const { selectedAccountBook } = useUserCtx();
 
@@ -62,6 +62,7 @@ const VoucherDetailPageBody: React.FC<IVoucherDetailPageBodyProps> = ({ voucherI
     payableInfo,
     receivingInfo,
     reverseVoucherIds,
+    deletedReverseVoucherIds,
     assets,
     lineItems,
     isReverseRelated,
@@ -77,9 +78,6 @@ const VoucherDetailPageBody: React.FC<IVoucherDetailPageBodyProps> = ({ voucherI
 
   const totalDebit = lineItems.reduce((acc, cur) => (cur.debit ? acc + cur.amount : acc), 0);
   const totalCredit = lineItems.reduce((acc, cur) => (!cur.debit ? acc + cur.amount : acc), 0);
-
-  // Info: (20241118 - Julian) If note is empty, display '-'
-  const noteText = note !== '' ? note : '-';
 
   // Info: (20241227 - Julian) type 字串轉換
   const translateType = (voucherType: string) => {
@@ -232,7 +230,27 @@ const VoucherDetailPageBody: React.FC<IVoucherDetailPageBodyProps> = ({ voucherI
   );
 
   const isDisplayNote = !isLoading ? (
-    <p className="text-input-text-primary">{noteText}</p>
+    <div className="flex flex-col">
+      {note && <p className="text-input-text-primary">{note}</p>}
+      {deletedReverseVoucherIds.length > 0 &&
+        deletedReverseVoucherIds.map((deletedReverseVoucherId) => (
+          <p className="text-text-neutral-tertiary">
+            {t('journal:VOUCHER_DETAIL_PAGE.DELETED_REVERSE_VOUCHER', {
+              voucherNo: (
+                <Link
+                  href={`/users/accounting/${deletedReverseVoucherId.id}?voucherNo=${deletedReverseVoucherId.voucherNo}`}
+                  className="text-link-text-primary hover:underline"
+                >
+                  {deletedReverseVoucherId.voucherNo}
+                </Link>
+              ),
+            })}
+          </p>
+        ))}
+      {!note && deletedReverseVoucherIds.length === 0 && (
+        <p className="text-input-text-primary">-</p>
+      )}
+    </div>
   ) : (
     <Skeleton width={200} height={24} rounded />
   );

--- a/src/interfaces/voucher.ts
+++ b/src/interfaces/voucher.ts
@@ -143,6 +143,10 @@ export interface IVoucherDetailForFrontend {
     id: number;
     voucherNo: string;
   }[];
+  deletedReverseVoucherIds: {
+    id: number;
+    voucherNo: string;
+  }[];
   assets: IAssetDetails[];
   certificates: ICertificate[];
   lineItems: (ILineItemBeta & {
@@ -181,6 +185,7 @@ export const defaultVoucherDetail: IVoucherDetailForFrontend = {
   payableInfo: undefined,
   receivingInfo: undefined,
   reverseVoucherIds: [],
+  deletedReverseVoucherIds: [],
   assets: [],
   certificates: [],
   lineItems: [],

--- a/src/lib/utils/zod_schema/voucher.ts
+++ b/src/lib/utils/zod_schema/voucher.ts
@@ -494,36 +494,32 @@ const voucherGetOneOutputValidatorV2 = z
                 voucherNo: associateVoucher.resultVoucher?.no,
               })) ?? []
           ) ?? []),
-          ...(data.resultEvents?.flatMap(
-            (event) =>
-              event.associateVouchers
-                ?.filter(
-                  (associateVoucher) =>
-                    associateVoucher.event?.eventType === 'revert' &&
-                    associateVoucher.originalVoucher
-                )
-                .map((associateVoucher) => ({
-                  id: associateVoucher.originalVoucher.id,
-                  voucherNo: associateVoucher.originalVoucher.no,
-                })) ?? []
-          ) ?? []),
+          ...(data.resultEvents
+            ?.filter((event) => event.eventType === 'revert')
+            ?.flatMap(
+              (event) =>
+                event.associateVouchers
+                  ?.filter((associateVoucher) => associateVoucher.originalVoucher)
+                  .map((associateVoucher) => ({
+                    id: associateVoucher.originalVoucher.id,
+                    voucherNo: associateVoucher.originalVoucher.no,
+                  })) ?? []
+            ) ?? []),
         ].map((item) => [item.id, item])
       ).values()
     );
-
     let deletedReverseVoucherIds =
-      data.resultEvents?.flatMap(
-        (event) =>
-          event.associateVouchers
-            ?.filter(
-              (associateVoucher) =>
-                associateVoucher.event?.eventType === 'delete' && associateVoucher.originalVoucher
-            )
-            .map((associateVoucher) => ({
-              id: associateVoucher.originalVoucher.id,
-              voucherNo: associateVoucher.originalVoucher.no,
-            })) ?? []
-      ) ?? [];
+      data.resultEvents
+        ?.filter((event) => event.eventType === 'delete')
+        ?.flatMap(
+          (event) =>
+            event.associateVouchers
+              ?.filter((associateVoucher) => associateVoucher.originalVoucher)
+              .map((associateVoucher) => ({
+                id: associateVoucher.originalVoucher.id,
+                voucherNo: associateVoucher.originalVoucher.no,
+              })) ?? []
+        ) ?? [];
 
     //  Info: (20250212 - Tzuhan) 過濾掉 `undefined`
     reverseVoucherIds = reverseVoucherIds.filter((voucher) => voucher.id && voucher.voucherNo);

--- a/src/locales/cn/journal.json
+++ b/src/locales/cn/journal.json
@@ -298,7 +298,7 @@
     "DELETE_SUCCESS_TOAST": "传票已删除。",
     "UNDO": "复原",
     "VOUCHER_NOT_FOUND": "找不到传票，请确认网址是否正确",
-    "DELETED_REVERSE_VOUCHER":  "因刪除 {{voucherNo}} 传票生成的反转分录"
+    "DELETED_REVERSE_VOUCHER":  "因刪除 <link>{{voucherNo}}</link> 传票生成的反转分录"
   },
   "LEDGER": {
     "LEDGER_PERIOD": "分类帐期间",

--- a/src/locales/cn/journal.json
+++ b/src/locales/cn/journal.json
@@ -297,7 +297,8 @@
     "DELETE_MESSAGE_SUBMIT_BTN": "是的，删除传票",
     "DELETE_SUCCESS_TOAST": "传票已删除。",
     "UNDO": "复原",
-    "VOUCHER_NOT_FOUND": "找不到传票，请确认网址是否正确"
+    "VOUCHER_NOT_FOUND": "找不到传票，请确认网址是否正确",
+    "DELETED_REVERSE_VOUCHER":  "因刪除 {{voucherNo}} 传票生成的反转分录"
   },
   "LEDGER": {
     "LEDGER_PERIOD": "分类帐期间",

--- a/src/locales/en/journal.json
+++ b/src/locales/en/journal.json
@@ -298,7 +298,7 @@
     "DELETE_SUCCESS_TOAST": "Vouchers have been deleted.",
     "UNDO": "Undo",
     "VOUCHER_NOT_FOUND": "Voucher not found, please make sure the URL is correct.",
-    "DELETED_REVERSE_VOUCHER": "{{voucherNo}} Reverse voucher (Delete)"
+    "DELETED_REVERSE_VOUCHER": "<link>{{voucherNo}}</link> Reverse voucher (Delete)"
   },
   "LEDGER": {
     "LEDGER_PERIOD": "Ledger Period",

--- a/src/locales/en/journal.json
+++ b/src/locales/en/journal.json
@@ -297,7 +297,8 @@
     "DELETE_MESSAGE_SUBMIT_BTN": "Yes, delete the voucher",
     "DELETE_SUCCESS_TOAST": "Vouchers have been deleted.",
     "UNDO": "Undo",
-    "VOUCHER_NOT_FOUND": "Voucher not found, please make sure the URL is correct."
+    "VOUCHER_NOT_FOUND": "Voucher not found, please make sure the URL is correct.",
+    "DELETED_REVERSE_VOUCHER": "{{voucherNo}} Reverse voucher (Delete)"
   },
   "LEDGER": {
     "LEDGER_PERIOD": "Ledger Period",

--- a/src/locales/tw/journal.json
+++ b/src/locales/tw/journal.json
@@ -298,7 +298,7 @@
     "DELETE_SUCCESS_TOAST": "傳票已刪除。",
     "UNDO": "復原",
     "VOUCHER_NOT_FOUND": "找不到傳票，請確認網址是否正確",
-    "DELETED_REVERSE_VOUCHER": "因刪除 {{voucherNo}} 傳票生成的反轉分錄"
+    "DELETED_REVERSE_VOUCHER": "因刪除 <link>{{voucherNo}}</link> 傳票生成的反轉分錄"
   },
   "LEDGER": {
     "LEDGER_PERIOD": "分類帳期間",

--- a/src/locales/tw/journal.json
+++ b/src/locales/tw/journal.json
@@ -297,7 +297,8 @@
     "DELETE_MESSAGE_SUBMIT_BTN": "是的，刪除傳票",
     "DELETE_SUCCESS_TOAST": "傳票已刪除。",
     "UNDO": "復原",
-    "VOUCHER_NOT_FOUND": "找不到傳票，請確認網址是否正確"
+    "VOUCHER_NOT_FOUND": "找不到傳票，請確認網址是否正確",
+    "DELETED_REVERSE_VOUCHER": "因刪除 {{voucherNo}} 傳票生成的反轉分錄"
   },
   "LEDGER": {
     "LEDGER_PERIOD": "分類帳期間",

--- a/src/pages/api/v2/company/[companyId]/voucher/route_utils.ts
+++ b/src/pages/api/v2/company/[companyId]/voucher/route_utils.ts
@@ -1208,6 +1208,7 @@ export const mockVouchersReturn = [
         voucherNo: '240817-002',
       },
     ],
+    deletedReverseVoucherIds: [],
     issuer: {
       // Info: (20240927 - Murky) IUser
       id: 1001,


### PR DESCRIPTION
### DEVELOP

- [X] Description: 1. 修改 list voucher 的 db query 從而可以過濾掉沖銷傳票， 2. 將 get voucher by id 的 db query 裡面的 resultEvent裡面的associate voucher 對應的 origin voucher 分別整理到 deletedReverseVoucherId  跟 reverseVoucherId 3. 修改前端可以顯示 deletedReverseVoucherId

#### Related Issues

- [X] Issue Number:  [#4247](https://github.com/CAFECA-IO/iSunFA/issues/4247) [#4248](https://github.com/CAFECA-IO/iSunFA/issues/4248)  部分完成 [#4250](https://github.com/CAFECA-IO/iSunFA/issues/4250)

#### Checklist

- [x] Used `@` in import paths.
- [x] Verified naming convention compliance ([Naming Convention Guidelines](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md)).
- [x] Coding style verification: checked
- [x] new Library: 0
- [x] new Class / Component: 0
- [x] new loop: 0
- [x] new recursive: 0
- [x] high risk: 0
- [x] new sql: 0

#### UML Diagrams

- None

#### Additional Notes

- Ensured all links are up-to-date.
- Conducted thorough testing on responsive design changes.
- Documented any notable considerations or edge cases addressed.