### PR TITLE
Feature/certificate page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iSunFA",
-  "version": "0.10.0",
+  "version": "0.10.0+2",
   "private": false,
   "scripts": {
     "dev": "next dev",

--- a/src/components/certificate/counterparty_input.tsx
+++ b/src/components/certificate/counterparty_input.tsx
@@ -27,6 +27,7 @@ interface ICounterpartyInputProps {
   onSelect: (counterparty: ICounterpartyOptional) => void;
   flagOfSubmit?: boolean;
   className?: string;
+  labelClassName?: string;
 }
 
 export interface CounterpartyInputRef {
@@ -316,7 +317,7 @@ const CounterpartyInput = forwardRef<CounterpartyInputRef, ICounterpartyInputPro
 
     return (
       <div className={`relative flex w-full flex-1 flex-col items-start gap-2 ${className}`}>
-        <p className="text-sm font-semibold text-input-text-primary">
+        <p className={`text-sm font-semibold ${props.labelClassName ?? 'text-input-text-primary'}`}>
           {t('certificate:EDIT.COUNTERPARTY')}
           <span className="text-text-state-error">*</span>
         </p>

--- a/src/components/certificate/input_certificate_edit_modal.tsx
+++ b/src/components/certificate/input_certificate_edit_modal.tsx
@@ -671,7 +671,7 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
 
             <div className="flex w-full items-center gap-2">
               {/* Info: (20240924 - Anna) Price Before Tax */}
-              <div className="relative flex flex-col items-start gap-2 md:h-105px md:flex-1">
+              <div className="relative flex flex-col items-start gap-2 md:h-105px flex-1">
                 <p className="text-sm font-semibold text-neutral-300">
                   {t('certificate:EDIT.PRICE_BEFORE_TAX')}
                   <span className="text-text-state-error">*</span>
@@ -706,7 +706,7 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
               </div>
 
               {/* Info: (20250414 - Anna) Tax */}
-              <div className="relative flex flex-1 flex-col items-start gap-2 md:h-105px md:flex-1">
+              <div className="relative flex flex-col items-start gap-2 md:h-105px flex-1">
                 <p className="text-sm font-semibold text-neutral-300">
                   {t('certificate:EDIT.TAX')}
                   <span className="text-text-state-error">*</span>

--- a/src/components/certificate/input_certificate_edit_modal.tsx
+++ b/src/components/certificate/input_certificate_edit_modal.tsx
@@ -135,6 +135,9 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
   // Info: (20250414 - Anna) 用來記錄 setTimeout 的任務 ID，供 debounce 清除使用
   const debounceTimer = useRef<NodeJS.Timeout | null>(null);
 
+  // Info: (20250428 - Anna) 用來操作 input（focus 或 select）
+  const summarizedInvoiceInputRef = useRef<HTMLInputElement>(null);
+
   const handleInputChange = useCallback(
     (
       field: keyof typeof formState,
@@ -473,6 +476,59 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
                 </p>
               )}
             </div>
+
+            {/* Info: (20250428 - Anna) 輸入彙總發票張數 */}
+            {(formState.type === InvoiceType.PURCHASE_SUMMARIZED_TRIPLICATE_AND_ELECTRONIC ||
+              formState.type ===
+                InvoiceType.PURCHASE_SUMMARIZED_DUPLICATE_CASH_REGISTER_AND_OTHER) && (
+              <div className="flex w-full flex-col gap-2">
+                <p className="text-sm font-semibold text-neutral-300">
+                  {t('certificate:EDIT.TOTAL_OF_SUMMARIZED_INVOICES')}
+                  <span> </span>
+                  <span className="text-text-state-error">*</span>
+                </p>
+                <div className="flex w-full items-center">
+                  <input
+                    id="summarized-invoice-count"
+                    ref={summarizedInvoiceInputRef}
+                    type="number"
+                    value={
+                      formState.summarizedInvoiceCount !== undefined
+                        ? formState.summarizedInvoiceCount.toString()
+                        : '0'
+                    }
+                    onChange={(e) => {
+                      const inputValue = e.target.value;
+                      const numberValue = parseInt(inputValue, 10);
+                      if (inputValue === '') {
+                        handleInputChange('summarizedInvoiceCount', 0); // Info: (20250428 - Anna) 空的話直接設 0
+                      } else if (!Number.isNaN(numberValue)) {
+                        handleInputChange('summarizedInvoiceCount', numberValue);
+                      }
+                    }}
+                    // Info: (20250428 - Anna) 只在值是 0 或 undefined 時全部選取
+                    onFocus={() => {
+                      if (
+                        formState.summarizedInvoiceCount === undefined ||
+                        formState.summarizedInvoiceCount === 0
+                      ) {
+                        summarizedInvoiceInputRef.current?.select();
+                      }
+                    }}
+                    className={`h-44px w-16 flex-1 rounded-l-sm border border-input-stroke-input bg-input-surface-input-background p-16px text-right uppercase outline-none ${
+                      formState.summarizedInvoiceCount === 0 ||
+                      formState.summarizedInvoiceCount === undefined
+                        ? 'text-neutral-300'
+                        : 'text-neutral-600'
+                    }`}
+                    placeholder="0"
+                  />
+                  <div className="flex h-44px min-w-70px items-center justify-center rounded-r-sm border border-input-stroke-input bg-input-surface-input-background p-14px font-medium text-neutral-300 outline-none">
+                    {t('certificate:EDIT.COPIES')}
+                  </div>
+                </div>
+              </div>
+            )}
 
             {/* Info: (20240924 - Anna) Invoice Number */}
             <div className="relative flex w-full flex-1 flex-col items-start gap-2">

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -41,7 +41,7 @@ export const ISUNFA_ROUTE = {
   ADD_NEW_VOUCHER: '/users/accounting/add_new_voucher',
   VOUCHER_LIST: '/users/accounting/voucher_list',
   PAYABLE_RECEIVABLE_LIST: '/users/accounting/payable_receivable_list',
-  CERTIFICATE_LIST: '/users/accounting/certificate_list',
+  CERTIFICATE_LIST: '/users/accounting/input_certificate_list',
   ASSET_LIST: '/users/asset',
   USERS_MY_REPORTS: '/users/reports/my_reports',
   USERS_ANALYSES_REPORTS_VIEW: '/users/reports/analyses/view',

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -41,7 +41,7 @@ export const ISUNFA_ROUTE = {
   ADD_NEW_VOUCHER: '/users/accounting/add_new_voucher',
   VOUCHER_LIST: '/users/accounting/voucher_list',
   PAYABLE_RECEIVABLE_LIST: '/users/accounting/payable_receivable_list',
-  CERTIFICATE_LIST: '/users/accounting/input_certificate_list',
+  CERTIFICATE_LIST: '/users/accounting/certificate_list',
   ASSET_LIST: '/users/asset',
   USERS_MY_REPORTS: '/users/reports/my_reports',
   USERS_ANALYSES_REPORTS_VIEW: '/users/reports/analyses/view',

--- a/src/interfaces/invoice.ts
+++ b/src/interfaces/invoice.ts
@@ -97,6 +97,8 @@ export interface IInvoiceBeta {
   updatedAt: number;
   // Info: (20250421 - Anna) 扣抵類型
   deductionType?: string;
+  // Info: (20250428 - Anna) 彙總發票張數
+  summarizedInvoiceCount?: number;
 }
 
 export type IInvoiceBetaOptional = Partial<IInvoiceBeta>;

--- a/src/locales/cn/certificate.json
+++ b/src/locales/cn/certificate.json
@@ -100,7 +100,9 @@
     "CERTIFICATE_BY_CUSTOMS": "海关代征营业税缴纳证明书号码",
     "CHARACTERS": "14 个字符",
     "ENTER_ONE_INVOICE": "输入一个发票号码作为代表",
-    "REPRESENTATIVE_INVOICE": "代表发票号码"
+    "REPRESENTATIVE_INVOICE": "代表发票号码",
+    "TOTAL_OF_SUMMARIZED_INVOICES": "汇总发票合计",
+    "COPIES": "张"
   },
   "TYPE": {
     "TRIPLICATE": "三联",

--- a/src/locales/cn/certificate.json
+++ b/src/locales/cn/certificate.json
@@ -102,7 +102,9 @@
     "ENTER_ONE_INVOICE": "输入一个发票号码作为代表",
     "REPRESENTATIVE_INVOICE": "代表发票号码",
     "TOTAL_OF_SUMMARIZED_INVOICES": "汇总发票合计",
-    "COPIES": "张"
+    "COPIES": "张",
+    "ALLOWANCE_ISSUE_DATE": "（折让单）开立日期",
+    "DUPLICATE_INVOICE_TAX": "如果使用二联式发票，税额为 0"
   },
   "TYPE": {
     "TRIPLICATE": "三联",

--- a/src/locales/en/certificate.json
+++ b/src/locales/en/certificate.json
@@ -100,7 +100,9 @@
     "CERTIFICATE_BY_CUSTOMS": "Certificate of payment for business tax collected by Customs No.",
     "CHARACTERS": "14 characters",
     "ENTER_ONE_INVOICE": "Enter one invoice No as a reference",
-    "REPRESENTATIVE_INVOICE": "Representative Invoice No."
+    "REPRESENTATIVE_INVOICE": "Representative Invoice No.",
+    "TOTAL_OF_SUMMARIZED_INVOICES": "Total of Summarized Invoices",
+    "COPIES": "Copies"
   },
   "TYPE": {
     "TRIPLICATE": "Triplicate",

--- a/src/locales/en/certificate.json
+++ b/src/locales/en/certificate.json
@@ -102,7 +102,9 @@
     "ENTER_ONE_INVOICE": "Enter one invoice No as a reference",
     "REPRESENTATIVE_INVOICE": "Representative Invoice No.",
     "TOTAL_OF_SUMMARIZED_INVOICES": "Total of Summarized Invoices",
-    "COPIES": "Copies"
+    "COPIES": "Copies",
+    "ALLOWANCE_ISSUE_DATE": "(Allowance) Issue Date",
+    "DUPLICATE_INVOICE_TAX": "Tax = 0 if using Duplicate invoice"
   },
   "TYPE": {
     "TRIPLICATE": "Triplicate",

--- a/src/locales/tw/certificate.json
+++ b/src/locales/tw/certificate.json
@@ -100,7 +100,9 @@
     "CERTIFICATE_BY_CUSTOMS": "海關代徵營業稅繳納證明書號碼",
     "CHARACTERS": "14 個字符",
     "ENTER_ONE_INVOICE": "輸入一個發票號碼作為代表",
-    "REPRESENTATIVE_INVOICE": "代表發票號碼"
+    "REPRESENTATIVE_INVOICE": "代表發票號碼",
+    "TOTAL_OF_SUMMARIZED_INVOICES": "彙總發票合計",
+    "COPIES": "張"
   },
   "TYPE": {
     "TRIPLICATE": "三聯",

--- a/src/locales/tw/certificate.json
+++ b/src/locales/tw/certificate.json
@@ -102,7 +102,9 @@
     "ENTER_ONE_INVOICE": "輸入一個發票號碼作為代表",
     "REPRESENTATIVE_INVOICE": "代表發票號碼",
     "TOTAL_OF_SUMMARIZED_INVOICES": "彙總發票合計",
-    "COPIES": "張"
+    "COPIES": "張",
+    "ALLOWANCE_ISSUE_DATE": "（折讓單）開立日期",
+    "DUPLICATE_INVOICE_TAX": "如果使用二聯式發票，稅額為 0"
   },
   "TYPE": {
     "TRIPLICATE": "三聯",


### PR DESCRIPTION
### DEVELOP

- UI - 彙總發票張數
- 憑證為折讓單時，顯示的文本不同
- 如果使用二聯式發票，稅額為 0
  
#### Related Issues

- #5030 
- #5029
- #5028

#### Checklist

- [x] Used `@` in import paths.
- [x] Verified naming convention compliance ([Naming Convention Guidelines](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md)).
- [x] Coding style verification: checked
- [x] new Library: 0
- [x] new Class / Component: 0
- [x] new loop: 0
- [x] new recursive: 0
- [x] high risk: 0
- [x] new sql: 0

#### UML Diagrams

- None

#### Additional Notes

- Ensured all links are up-to-date.
- Conducted thorough testing on responsive design changes.
- Documented any notable considerations or edge cases addressed.