### PR TITLE
Hide Counterparty and Tax fields when Invoice Type is Type-32

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iSunFA",
-  "version": "0.10.0+4",
+  "version": "0.10.0+5",
   "private": false,
   "scripts": {
     "dev": "next dev",

--- a/src/components/certificate/input_certificate_edit_modal.tsx
+++ b/src/components/certificate/input_certificate_edit_modal.tsx
@@ -26,6 +26,7 @@ import { APIName } from '@/constants/api_connection';
 import TaxMenu from '@/components/certificate/certificate_tax_menu_new';
 import DeductionTypeMenu from '@/components/certificate/certificate_deduction_type_menu';
 import { IPaginatedData } from '@/interfaces/pagination';
+import { HiCheck } from 'react-icons/hi';
 
 interface InputCertificateEditModalProps {
   isOpen: boolean;
@@ -100,8 +101,12 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
         counterParty: certificate.invoice.counterParty,
         type: certificate.invoice.type ?? InvoiceType.PURCHASE_TRIPLICATE_AND_ELECTRONIC,
         deductible: certificate.invoice.deductible,
-        // Info: (20250422 - Anna) 多存「扣抵類型」
+        // Info: (20250422 - Anna)「扣抵類型」
         deductionType: certificate.invoice.deductionType ?? 'DEDUCTIBLE_PURCHASE_AND_EXPENSE',
+        // Info: (20250429 - Anna)「是否為彙總金額代表憑證」
+        isSharedAmount: certificate.invoice.isSharedAmount ?? false,
+        // Info: (20250429 - Anna)「其他憑證編號」
+        otherCertificateNo: certificate.invoice.otherCertificateNo ?? '',
       }) as IInvoiceBetaOptional
   );
   const [errors] = useState<Record<string, string>>({});
@@ -257,6 +262,11 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
       ...certificate.invoice,
       ...formStateRef.current,
     };
+    // ToDo: (20250429 - Anna) 等後端欄位完成，確認 isSharedAmount 正確存取後，移除 console.log
+    // eslint-disable-next-line no-console
+    console.log('傳到後端的 isSharedAmount(formStateRef):', formStateRef.current.isSharedAmount);
+    // eslint-disable-next-line no-console
+    console.log('傳到後端的 isSharedAmount(updatedInvoice):', updatedInvoice.isSharedAmount);
 
     // Info: (20250414 - Anna) 如果資料完全沒變，就不打 API
     if (shallowEqual(savedInvoiceRef.current, updatedInvoice)) return;
@@ -441,7 +451,6 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
                 </div>
               </div>
             </div>
-
             {/* Info: (20240924 - Anna) Invoice Date */}
             <div className="flex w-full flex-col items-start gap-2">
               <p className="text-sm font-semibold text-neutral-300">
@@ -465,7 +474,6 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
                 </p>
               )}
             </div>
-
             {/* Info: (20250428 - Anna) 輸入彙總發票張數 */}
             {(formState.type === InvoiceType.PURCHASE_SUMMARIZED_TRIPLICATE_AND_ELECTRONIC ||
               formState.type ===
@@ -518,7 +526,6 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
                 </div>
               </div>
             )}
-
             {/* Info: (20240924 - Anna) Invoice Number */}
             <div className="relative flex w-full flex-1 flex-col items-start gap-2">
               <div id="price" className="absolute -top-20"></div>
@@ -543,7 +550,8 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
                     />
                   </div>
                 </>
-              ) : formState.type === InvoiceType.PURCHASE_SUMMARIZED_TRIPLICATE_AND_ELECTRONIC ? (
+              ) : // Info: (20250429 - Anna) 格式26
+              formState.type === InvoiceType.PURCHASE_SUMMARIZED_TRIPLICATE_AND_ELECTRONIC ? (
                 <>
                   <p className="text-sm font-semibold text-neutral-300">
                     {t('certificate:EDIT.REPRESENTATIVE_INVOICE')}
@@ -582,13 +590,82 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
                     />
                   </div>
                 </>
+              ) : // Info: (20250429 - Anna) 格式22
+              formState.type === InvoiceType.PURCHASE_DUPLICATE_CASH_REGISTER_AND_OTHER ? (
+                <div className="flex w-full justify-between">
+                  {/* Info: (20250429 - Anna) Invoice No. */}
+                  <div className="flex flex-col gap-2 md:w-52">
+                    <p className="text-sm font-semibold text-neutral-300">
+                      {t('certificate:EDIT.INVOICE_NUMBER')}
+                      <span> </span>
+                      <span className="text-text-state-error">*</span>
+                    </p>
+
+                    <div className="flex items-center">
+                      {/* Info: (20250415 - Anna) 「輸入」發票前綴 */}
+                      <input
+                        id="invoice-prefix"
+                        type="text"
+                        maxLength={2}
+                        value={formState.no?.substring(0, 2) ?? ''}
+                        onChange={(e) => {
+                          const latestNo = formStateRef.current.no ?? '';
+                          const suffix = latestNo.substring(2);
+                          handleInputChange('no', `${e.target.value.toUpperCase()}${suffix}`);
+                        }}
+                        className="h-44px w-16 rounded-l-sm border border-input-stroke-input bg-input-surface-input-background p-16px text-center uppercase outline-none"
+                        placeholder="AB"
+                        disabled={!!formState.otherCertificateNo}
+                      />
+
+                      <input
+                        id="invoice-number"
+                        type="text"
+                        maxLength={8}
+                        value={formState.no?.substring(2) ?? ''}
+                        onChange={(e) => {
+                          const latestNo = formStateRef.current.no ?? '';
+                          const prefix = latestNo.substring(0, 2);
+                          handleInputChange('no', `${prefix}${e.target.value}`);
+                        }}
+                        className="h-44px rounded-r-sm border border-input-stroke-input bg-input-surface-input-background p-16px outline-none md:w-36"
+                        placeholder="12345678"
+                        disabled={!!formState.otherCertificateNo}
+                      />
+                    </div>
+                  </div>
+                  {/* Info: (20250429 - Anna) or */}
+                  <p className="flex items-end text-neutral-400">{t('common:COMMON.OR')}</p>
+                  {/* Info: (20250429 - Anna) Other Certificate No. */}
+                  <div className="flex flex-col gap-2 md:w-52">
+                    <p className="text-sm font-semibold text-neutral-300">
+                      {t('certificate:EDIT.OTHER_CERTIFICATE_NO')}
+                      <span> </span>
+                      <span className="text-text-state-error">*</span>
+                    </p>
+
+                    <div className="flex w-full items-center">
+                      <input
+                        id="other-certificate-no"
+                        type="text"
+                        value={formState.otherCertificateNo ?? ''}
+                        onChange={(e) => {
+                          handleInputChange('otherCertificateNo', e.target.value);
+                        }}
+                        className="h-44px flex-1 rounded-sm border border-input-stroke-input bg-input-surface-input-background p-16px outline-none"
+                        placeholder="CC12345678"
+                        disabled={!!formState.no}
+                      />
+                    </div>
+                  </div>
+                </div>
               ) : (
+                // Info: (20250415 - Anna) 其他憑證類型的UI
                 <>
                   <p className="text-sm font-semibold text-neutral-300">
                     {t('certificate:EDIT.INVOICE_NUMBER')}
                     <span className="text-text-state-error">*</span>
                   </p>
-                  {/* Info: (20250415 - Anna) 其他憑證類型的UI */}
                   <div className="flex w-full items-center">
                     {/* Info: (20250415 - Anna) 「輸入」發票前綴 */}
                     <input
@@ -622,7 +699,6 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
                 </>
               )}
             </div>
-
             {/* Info: (20250414 - Anna) Tax Type */}
             <div className="flex w-full flex-col items-start gap-2">
               <p className="text-sm font-semibold text-neutral-300">
@@ -639,7 +715,6 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
                 </p>
               )}
             </div>
-
             {/* Info: (20250421 - Anna) Deduction Type */}
             <div className="flex w-full flex-col items-start gap-2">
               <p className="text-sm font-semibold text-neutral-300">
@@ -650,7 +725,6 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
                 <DeductionTypeMenu selectDeductionTypeHandler={selectDeductionTypeHandler} />
               </div>
             </div>
-
             {/* Info: (20240924 - Anna) CounterParty */}
             <CounterpartyInput
               ref={counterpartyInputRef}
@@ -668,10 +742,9 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
                 {errors.counterParty}
               </p>
             )}
-
             <div className="flex w-full items-center gap-2">
               {/* Info: (20240924 - Anna) Price Before Tax */}
-              <div className="relative flex flex-col items-start gap-2 md:h-105px flex-1">
+              <div className="relative flex flex-1 flex-col items-start gap-2 md:h-105px">
                 <p className="text-sm font-semibold text-neutral-300">
                   {t('certificate:EDIT.PRICE_BEFORE_TAX')}
                   <span className="text-text-state-error">*</span>
@@ -706,7 +779,7 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
               </div>
 
               {/* Info: (20250414 - Anna) Tax */}
-              <div className="relative flex flex-col items-start gap-2 md:h-105px flex-1">
+              <div className="relative flex flex-1 flex-col items-start gap-2 md:h-105px">
                 <p className="text-sm font-semibold text-neutral-300">
                   {t('certificate:EDIT.TAX')}
                   <span className="text-text-state-error">*</span>
@@ -758,7 +831,6 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
                 )}
               </div>
             </div>
-
             {/* Info: (20240924 - Anna) Total Price */}
             <div className="hidden">
               <div className="relative flex w-full flex-1 flex-col items-start gap-2">
@@ -796,6 +868,35 @@ const InputCertificateEditModal: React.FC<InputCertificateEditModalProps> = ({
                 )}
               </div>
             </div>
+            {/* Info: (20250429 - Anna) Mark as shared amount checkbox */}
+            {formState.type === InvoiceType.PURCHASE_UTILITY_ELECTRONIC_INVOICE && (
+              <div className="flex w-full items-center gap-2">
+                <div
+                  className={`relative h-16px w-16px rounded-xxs border border-checkbox-stroke-unselected ${
+                    formState.isSharedAmount
+                      ? 'bg-checkbox-surface-selected'
+                      : 'bg-checkbox-surface-unselected'
+                  }`}
+                  onClick={() => {
+                    const isTogglingToSharedAmount = !(
+                      formStateRef.current.isSharedAmount ?? false
+                    );
+                    handleInputChange('isSharedAmount', isTogglingToSharedAmount);
+                  }}
+                >
+                  {formState.isSharedAmount && (
+                    <div className="absolute inset-0 flex items-center justify-center">
+                      <HiCheck className="text-neutral-white" />
+                    </div>
+                  )}
+                </div>
+
+                {/* Info: (20250414 - Anna) Checkbox label */}
+                <span className="text-sm font-medium text-input-text-primary">
+                  {t('certificate:INPUT_CERTIFICATE.MARK_AS_SHARED_AMOUNT')}
+                </span>
+              </div>
+            )}
           </div>
         </div>
         {/* Info: (20240924 - Anna) Save 按鈕 */}

--- a/src/components/certificate/output_certificate_edit_modal.tsx
+++ b/src/components/certificate/output_certificate_edit_modal.tsx
@@ -419,10 +419,12 @@ const OutputCertificateEditModal: React.FC<OutputCertificateEditModalProps> = ({
         />
 
         {/* Info: (20241210 - Anna) 隱藏 scrollbar */}
-        <div className="hide-scrollbar flex md:h-600px w-full items-start justify-between gap-5 overflow-y-scroll md:flex-row">
+        <div className="hide-scrollbar flex w-full items-start justify-between gap-5 overflow-y-scroll md:h-600px md:flex-row">
           {/* Info: (20240924 - Anna) 發票縮略圖 */}
           <ImageZoom
-            imageUrl={certificate.file.url}
+            // Todo: (20250428 - Anna) 先用假憑證測試
+            // imageUrl={certificate.file.url}
+            imageUrl={'/images/demo_certifate.png'}
             className="max-h-630px min-h-450px w-440px"
             controlPosition="bottom-right"
           />
@@ -431,7 +433,7 @@ const OutputCertificateEditModal: React.FC<OutputCertificateEditModalProps> = ({
           <div className="hide-scrollbar flex h-600px w-full flex-col items-start space-y-4 overflow-y-scroll pb-80px">
             {/* Info: (20240924 - Anna) Invoice Type */}
             <div className="flex w-full flex-col items-start gap-2">
-              <p className="text-sm font-semibold text-input-text-primary">
+              <p className="text-sm font-semibold text-neutral-300">
                 {t('certificate:EDIT.INVOICE_TYPE')}
                 <span className="text-text-state-error">*</span>
               </p>
@@ -476,7 +478,7 @@ const OutputCertificateEditModal: React.FC<OutputCertificateEditModalProps> = ({
 
             {/* Info: (20240924 - Anna) Invoice Date */}
             <div className="flex w-full flex-col items-start gap-2">
-              <p className="text-sm font-semibold text-input-text-primary">
+              <p className="text-sm font-semibold text-neutral-300">
                 {t('certificate:EDIT.DATE')}
                 <span className="text-text-state-error">*</span>
               </p>
@@ -495,9 +497,9 @@ const OutputCertificateEditModal: React.FC<OutputCertificateEditModalProps> = ({
             </div>
 
             {/* Info: (20240924 - Anna) Invoice Number */}
-            <div className="relative flex w-full flex-1 flex-col items-start gap-2">
+            <div className="relative flex w-full flex-col items-start gap-2">
               <div id="price" className="absolute -top-20"></div>
-              <p className="text-sm font-semibold text-input-text-primary">
+              <p className="text-sm font-semibold text-neutral-300">
                 {t('certificate:EDIT.INVOICE_NUMBER')}
                 <span className="text-text-state-error">*</span>
               </p>
@@ -599,27 +601,31 @@ const OutputCertificateEditModal: React.FC<OutputCertificateEditModalProps> = ({
             </div>
 
             {/* Info: (20240924 - Anna) CounterParty */}
-            <CounterpartyInput
-              ref={counterpartyInputRef}
-              counterparty={formState.counterParty}
-              counterpartyList={counterpartyList}
-              onSelect={(cp: ICounterpartyOptional) => {
-                if (cp && cp.name) {
-                  handleInputChange('counterParty', cp);
-                }
-              }}
-            />
-            {errors.counterParty && (
-              <p className="-translate-y-1 self-end text-sm text-text-state-error">
-                {errors.counterParty}
-              </p>
+            {formState.type !== InvoiceType.SALES_DUPLICATE_CASH_REGISTER_INVOICE && (
+              <>
+                <CounterpartyInput
+                  ref={counterpartyInputRef}
+                  counterparty={formState.counterParty}
+                  counterpartyList={counterpartyList}
+                  onSelect={(cp: ICounterpartyOptional) => {
+                    if (cp && cp.name) {
+                      handleInputChange('counterParty', cp);
+                    }
+                  }}
+                  labelClassName="text-neutral-300"
+                />
+                {errors.counterParty && (
+                  <p className="-translate-y-1 self-end text-sm text-text-state-error">
+                    {errors.counterParty}
+                  </p>
+                )}
+              </>
             )}
 
             <div className="flex w-full items-center gap-2">
               {/* Info: (20240924 - Anna) Price Before Tax */}
               <div className="relative flex flex-1 flex-col items-start gap-2">
-                <div id="price" className="absolute -top-20"></div>
-                <p className="text-sm font-semibold text-input-text-primary">
+                <p className="text-sm font-semibold text-neutral-300">
                   {t('certificate:EDIT.PRICE_BEFORE_TAX')}
                   <span className="text-text-state-error">*</span>
                 </p>
@@ -631,7 +637,7 @@ const OutputCertificateEditModal: React.FC<OutputCertificateEditModalProps> = ({
                     isDecimal
                     required
                     hasComma
-                    className="h-46px flex-1 rounded-l-sm border border-input-stroke-input bg-input-surface-input-background p-10px text-right outline-none"
+                    className="h-46px w-full rounded-l-sm border border-input-stroke-input bg-input-surface-input-background p-10px text-right outline-none"
                     triggerWhenChanged={priceBeforeTaxChangeHandler}
                   />
                   <div className="flex h-46px w-91px min-w-91px items-center gap-4px rounded-r-sm border border-l-0 border-input-stroke-input bg-input-surface-input-background p-14px text-sm text-input-text-input-placeholder">
@@ -651,35 +657,38 @@ const OutputCertificateEditModal: React.FC<OutputCertificateEditModalProps> = ({
                   </p>
                 )}
               </div>
-
-              {/* Info: (20250414 - Anna) Tax */}
-              <div className="relative flex flex-1 flex-col items-start gap-2">
-                <p className="text-sm font-semibold text-input-text-primary">
-                  Tax
-                  <span className="text-text-state-error">*</span>
-                </p>
-                <div className="flex w-full items-center">
-                  <NumericInput
-                    id="input-tax"
-                    name="input-tax"
-                    value={formState.taxPrice ?? 0}
-                    isDecimal
-                    required
-                    hasComma
-                    className="h-46px flex-1 rounded-l-sm border border-input-stroke-input bg-input-surface-input-background p-10px text-right outline-none"
-                  />
-                  <div className="flex h-46px w-91px min-w-91px items-center gap-4px rounded-r-sm border border-l-0 border-input-stroke-input bg-input-surface-input-background p-14px text-sm text-input-text-input-placeholder">
-                    <Image
-                      src={currencyAliasImageSrc}
-                      width={16}
-                      height={16}
-                      alt={currencyAliasImageAlt}
-                      className="rounded-full"
-                    />
-                    <p>{currencyAliasStr}</p>
+              {formState.type !== InvoiceType.SALES_DUPLICATE_CASH_REGISTER_INVOICE && (
+                <>
+                  {/* Info: (20250414 - Anna) Tax */}
+                  <div className="relative flex flex-1 flex-col items-start gap-2">
+                    <p className="text-sm font-semibold text-neutral-300">
+                      {t('certificate:EDIT.TAX')}
+                      <span className="text-text-state-error">*</span>
+                    </p>
+                    <div className="flex w-full items-center">
+                      <NumericInput
+                        id="input-tax"
+                        name="input-tax"
+                        value={formState.taxPrice ?? 0}
+                        isDecimal
+                        required
+                        hasComma
+                        className="h-46px w-full rounded-l-sm border border-input-stroke-input bg-input-surface-input-background p-10px text-right outline-none"
+                      />
+                      <div className="flex h-46px w-91px min-w-91px items-center gap-4px rounded-r-sm border border-l-0 border-input-stroke-input bg-input-surface-input-background p-14px text-sm text-input-text-input-placeholder">
+                        <Image
+                          src={currencyAliasImageSrc}
+                          width={16}
+                          height={16}
+                          alt={currencyAliasImageAlt}
+                          className="rounded-full"
+                        />
+                        <p>{currencyAliasStr}</p>
+                      </div>
+                    </div>
                   </div>
-                </div>
-              </div>
+                </>
+              )}
             </div>
 
             {/* Info: (20240924 - Anna) Total Price */}

--- a/src/components/certificate/output_certificate_edit_modal.tsx
+++ b/src/components/certificate/output_certificate_edit_modal.tsx
@@ -422,9 +422,7 @@ const OutputCertificateEditModal: React.FC<OutputCertificateEditModalProps> = ({
         <div className="hide-scrollbar flex w-full items-start justify-between gap-5 overflow-y-scroll md:h-600px md:flex-row">
           {/* Info: (20240924 - Anna) 發票縮略圖 */}
           <ImageZoom
-            // Todo: (20250428 - Anna) 先用假憑證測試
-            // imageUrl={certificate.file.url}
-            imageUrl={'/images/demo_certifate.png'}
+            imageUrl={certificate.file.url}
             className="max-h-630px min-h-450px w-440px"
             controlPosition="bottom-right"
           />

--- a/src/interfaces/invoice.ts
+++ b/src/interfaces/invoice.ts
@@ -99,6 +99,10 @@ export interface IInvoiceBeta {
   deductionType?: string;
   // Info: (20250428 - Anna) 彙總發票張數
   summarizedInvoiceCount?: number;
+  // Info: (20250429 - Anna) 是否為彙總金額代表憑證
+  isSharedAmount?: boolean;
+  // Info: (20250429 - Anna) 其他憑證編號
+  otherCertificateNo?: string;
 }
 
 export type IInvoiceBetaOptional = Partial<IInvoiceBeta>;

--- a/src/locales/cn/certificate.json
+++ b/src/locales/cn/certificate.json
@@ -104,7 +104,8 @@
     "TOTAL_OF_SUMMARIZED_INVOICES": "汇总发票合计",
     "COPIES": "张",
     "ALLOWANCE_ISSUE_DATE": "（折让单）开立日期",
-    "DUPLICATE_INVOICE_TAX": "如果使用二联式发票，税额为 0"
+    "DUPLICATE_INVOICE_TAX": "如果使用二联式发票，税额为 0",
+    "OTHER_CERTIFICATE_NO": "其他凭证编号"
   },
   "TYPE": {
     "TRIPLICATE": "三联",
@@ -206,6 +207,7 @@
     "NEXT": "下一笔"
   },
   "INPUT_CERTIFICATE": {
-    "INPUT_CERTIFICATE": "进项凭证"
+    "INPUT_CERTIFICATE": "进项凭证",
+    "MARK_AS_SHARED_AMOUNT": "勾选表示此为汇总金额代表凭证"
   }
 }

--- a/src/locales/en/certificate.json
+++ b/src/locales/en/certificate.json
@@ -104,7 +104,8 @@
     "TOTAL_OF_SUMMARIZED_INVOICES": "Total of Summarized Invoices",
     "COPIES": "Copies",
     "ALLOWANCE_ISSUE_DATE": "(Allowance) Issue Date",
-    "DUPLICATE_INVOICE_TAX": "Tax = 0 if using Duplicate invoice"
+    "DUPLICATE_INVOICE_TAX": "Tax = 0 if using Duplicate invoice",
+    "OTHER_CERTIFICATE_NO": "Other Certificate No. *"
   },
   "TYPE": {
     "TRIPLICATE": "Triplicate",
@@ -206,6 +207,7 @@
     "NEXT": "Next"
   },
   "INPUT_CERTIFICATE": {
-    "INPUT_CERTIFICATE": "Input Invoice"
+    "INPUT_CERTIFICATE": "Input Invoice",
+    "MARK_AS_SHARED_AMOUNT": "Mark as shared amount"
   }
 }

--- a/src/locales/tw/certificate.json
+++ b/src/locales/tw/certificate.json
@@ -104,7 +104,8 @@
     "TOTAL_OF_SUMMARIZED_INVOICES": "彙總發票合計",
     "COPIES": "張",
     "ALLOWANCE_ISSUE_DATE": "（折讓單）開立日期",
-    "DUPLICATE_INVOICE_TAX": "如果使用二聯式發票，稅額為 0"
+    "DUPLICATE_INVOICE_TAX": "如果使用二聯式發票，稅額為 0",
+    "OTHER_CERTIFICATE_NO": "其他憑證編號"
   },
   "TYPE": {
     "TRIPLICATE": "三聯",
@@ -206,6 +207,7 @@
     "NEXT": "下一筆"
   },
   "INPUT_CERTIFICATE": {
-    "INPUT_CERTIFICATE": "進項憑證"
+    "INPUT_CERTIFICATE": "進項憑證",
+    "MARK_AS_SHARED_AMOUNT": "勾選表示此為彙總金額代表憑證"
   }
 }


### PR DESCRIPTION
### DEVELOP

- Hide "Counterparty" and "Tax" fields when Invoice Type is SALES_DUPLICATE_CASH_REGISTER_INVOICE (Type 32)
- [進項憑證頁面] - 格式25 - Mark as shared amount" checkbox
- [進銷項憑證頁面] - 不同發票格式，顯示不同UI
  
#### Related Issues

- #5045 
- #5026 
- #5027

#### Checklist

- [x] Used `@` in import paths.
- [x] Verified naming convention compliance ([Naming Convention Guidelines](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md)).
- [x] Coding style verification: checked
- [x] new Library: 0
- [x] new Class / Component: 0
- [x] new loop: 0
- [x] new recursive: 0
- [x] high risk: 0
- [x] new sql: 0

#### UML Diagrams

- None

#### Additional Notes

- Ensured all links are up-to-date.
- Conducted thorough testing on responsive design changes.
- Documented any notable considerations or edge cases addressed.