### PR TITLE
Hotfix: fix mission executor and issue recorder

### DIFF
--- a/src/services/issue.recorder.service.ts
+++ b/src/services/issue.recorder.service.ts
@@ -6,6 +6,7 @@ import { Prisma } from "@/generated";
 import { ORDER_STATUS } from "@/constants/status";
 import { syncDocumentResultToDatabase } from "@/skills/utils/document_parser_db_sync";
 import { getPriorityEnvConfig } from "@/services/env.service";
+import type { IAggregatedDocumentResult } from "@/skills/utils/document_parser_db_sync";
 
 export class IssueRecorderService {
   async processNext() {
@@ -146,13 +147,26 @@ export class IssueRecorderService {
                 string,
                 Record<string, unknown>
               >;
-              for (const fileId of Object.keys(payload)) {
-                const fileResult = payload[fileId];
-                await syncDocumentResultToDatabase(
-                  fileId,
-                  fileResult.accountBookId as string,
-                  fileResult as unknown as import("@/skills/utils/document_parser_db_sync").IAggregatedDocumentResult,
-                );
+              for (const recordKey of Object.keys(payload)) {
+                const fileResult = payload[recordKey];
+                const fileIdToSync =
+                  typeof fileResult.fileId === "string"
+                    ? fileResult.fileId
+                    : recordKey;
+                await syncDocumentResultToDatabase({
+                  fileId: fileIdToSync,
+                  accountBookId: fileResult.accountBookId as string,
+                  result: fileResult as unknown as IAggregatedDocumentResult,
+                  voucherIdContext: fileResult.voucherIdContext as
+                    | string
+                    | undefined,
+                  esgRecordIdContext: fileResult.esgRecordIdContext as
+                    | string
+                    | undefined,
+                  journalIdContext: fileResult.journalIdContext as
+                    | string
+                    | undefined,
+                });
               }
               console.log(
                 `[MissionRecorder] Synced document results to DB for Task ID ${taskId}`,

--- a/src/services/mission.executor.service.ts
+++ b/src/services/mission.executor.service.ts
@@ -1,12 +1,13 @@
-import { getPriorityEnvConfig } from "@/services/env.service";
 import fs from "fs/promises";
 import path from "path";
+import { getPriorityEnvConfig } from "@/services/env.service";
 import { ChatService } from "@/services/chat.service";
 import { skillRegistry } from "@/skills";
 import { IMissionDefinition } from "@/lib/worker/mission.generator";
 import { ITaskDefinition } from "@/lib/worker/task.generator";
 import { Prisma } from "@/generated";
 import { IPseudoTask, IPseudoMission } from "@/skills/types";
+
 export async function processNext() {
   console.log("[MissionExecutor] Scanning MISSION_DIR for tasks to execute...");
 
@@ -213,23 +214,34 @@ export async function processNext() {
             if (useJsonPlan && subTaskConfig.data?.context) {
               try {
                 const ctx = JSON.parse(subTaskConfig.data.context as string);
-                if (ctx.fileId && ctx.accountBookId) {
-                  if (!aggregatedResultsByFileId[ctx.fileId]) {
-                    aggregatedResultsByFileId[ctx.fileId] = {
+                const recordKey =
+                  ctx.fileId ||
+                  ctx.voucherId ||
+                  ctx.esgRecordId ||
+                  ctx.journalId ||
+                  "default";
+
+                if (recordKey && ctx.accountBookId) {
+                  if (!aggregatedResultsByFileId[recordKey]) {
+                    aggregatedResultsByFileId[recordKey] = {
                       accountBookId: ctx.accountBookId,
+                      fileId: ctx.fileId || "",
+                      voucherIdContext: ctx.voucherId || "",
+                      esgRecordIdContext: ctx.esgRecordId || "",
+                      journalIdContext: ctx.journalId || "",
                     };
                   }
 
                   if (subTaskConfig.type === "JOURNAL_PARSING")
-                    aggregatedResultsByFileId[ctx.fileId].journal = parsedVal;
+                    aggregatedResultsByFileId[recordKey].journal = parsedVal;
                   if (subTaskConfig.type === "VOUCHER_BASE_PARSING")
-                    aggregatedResultsByFileId[ctx.fileId].voucherBase =
+                    aggregatedResultsByFileId[recordKey].voucherBase =
                       parsedVal;
                   if (subTaskConfig.type === "VOUCHER_LINES_PARSING")
-                    aggregatedResultsByFileId[ctx.fileId].voucherLines =
+                    aggregatedResultsByFileId[recordKey].voucherLines =
                       parsedVal;
                   if (subTaskConfig.type === "ESG_PARSING")
-                    aggregatedResultsByFileId[ctx.fileId].esg = parsedVal;
+                    aggregatedResultsByFileId[recordKey].esg = parsedVal;
                 }
               } catch {}
             }

--- a/src/skills/utils/document_parser_db_sync.ts
+++ b/src/skills/utils/document_parser_db_sync.ts
@@ -52,14 +52,27 @@ export interface IAggregatedDocumentResult {
   failureReason?: string;
 }
 
-export async function syncDocumentResultToDatabase(
-  fileId: string,
-  accountBookId: string,
-  result: IAggregatedDocumentResult,
-  voucherIdContext?: string,
-  esgRecordIdContext?: string,
-) {
-  if (!accountBookId || (!fileId && !voucherIdContext && !esgRecordIdContext)) {
+export interface ISyncDocumentResultParams {
+  fileId: string;
+  accountBookId: string;
+  result: IAggregatedDocumentResult;
+  voucherIdContext?: string;
+  esgRecordIdContext?: string;
+  journalIdContext?: string;
+}
+
+export async function syncDocumentResultToDatabase({
+  fileId,
+  accountBookId,
+  result,
+  voucherIdContext,
+  esgRecordIdContext,
+  journalIdContext,
+}: ISyncDocumentResultParams) {
+  if (
+    !accountBookId ||
+    (!fileId && !voucherIdContext && !esgRecordIdContext && !journalIdContext)
+  ) {
     return false;
   }
 
@@ -89,7 +102,11 @@ export async function syncDocumentResultToDatabase(
     // Info: (20260420 - Luphia) 1. Sync Journal
     if (journal || failureReason) {
       let existingJournal = null;
-      if (realFileId && accountBookId) {
+      if (journalIdContext) {
+        existingJournal = await tx.journal.findUnique({
+          where: { id: journalIdContext },
+        });
+      } else if (realFileId && accountBookId) {
         existingJournal = await tx.journal.findFirst({
           where: { fileId: realFileId, accountBookId },
         });


### PR DESCRIPTION
### DEVELOP

- [X] Description: Fixed an issue where the analysis completion of an existing journal voucher would create a new `esg_record` and `voucher` instead of updating the existing ones. Extracted `voucherId` and `esgRecordId` from the mission execution context and ensured they are correctly passed to `syncDocumentResultToDatabase` via `dbSyncPayload` during the issue recording phase.
  
#### Related Issues

- [X] Issue Number: #<Replace_with_Issue_Number>

#### Checklist

- [x] Used `@` in import paths.
- [x] Verified naming convention compliance ([Naming Convention Guidelines](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md)).
- [x] Coding style verification: checked
- [x] new Library: 0
- [x] new Class / Component: 0
- [x] new loop: 0
- [x] new recursive: 0
- [x] high risk: 0
- [x] new sql: 0

#### UML Diagrams

- None

#### Additional Notes

- Ensured that the DB sync process accurately references the existing `esgRecordId` or `voucherId` without falling back to a blind `fileId` search.
- Added a safety check in `issue.recorder.service.ts` to properly resolve `fileIdToSync`, preventing missing file hashes (e.g., from manual journals) from inadvertently creating empty files in the DB.
