### PR TITLE
feat(carbon-chatbot): report outline navigation with vibe-mode sectio…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isunfa",
-  "version": "0.12.0+159",
+  "version": "0.12.0+160",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/app/user/carbon_chatbot/page.tsx
+++ b/src/app/user/carbon_chatbot/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { useState } from "react";
+import { FileText, ListTree, X } from "lucide-react";
 import { useCarbonChat } from "@/hooks/use_carbon_chat";
 import { useTranslation } from "@/i18n/i18n_context";
+import { OutlineModal } from "@/components/carbon_chatbot/outline_modal";
 import { ChatHeader } from "@/components/carbon_chatbot/chat_header";
 import { ChatSidebar } from "@/components/carbon_chatbot/chat_sidebar";
 import { ChatArea } from "@/components/carbon_chatbot/chat_area";
@@ -26,11 +29,19 @@ export default function CarbonChatbotPage() {
     isLoadingHistory,
     loadMoreHistory,
     handleSendMessage,
-    toggleParagraphCompleted,
+    reportStats,
+    activeParagraphId,
+    jumpToParagraph,
     toggleParagraphVerified,
     handleMarkdownChange,
     chatEndRef,
   } = useCarbonChat();
+
+  // Info: (20260713 - Tzuhan) 行動版(<xl)右欄預覽隱藏,章節目錄改以 Modal、報告改以全螢幕覆蓋層呈現
+  const [isMobileOutlineOpen, setIsMobileOutlineOpen] =
+    useState<boolean>(false);
+  const [isMobileReportOpen, setIsMobileReportOpen] = useState<boolean>(false);
+  const paragraphs = activeSession?.reportData?.paragraphs ?? [];
 
   return (
     <div className="flex h-[calc(100vh-170px)] flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white text-sm shadow-[0_4px_20px_rgb(0,0,0,0.05)]">
@@ -66,6 +77,30 @@ export default function CarbonChatbotPage() {
                 onInputChange={setInputValue}
                 onSendMessage={handleSendMessage}
               />
+
+              {/* Info: (20260713 - Tzuhan) 行動版浮動鈕組:章節目錄 Modal 與報告全螢幕檢視(桌面由右欄操作) */}
+              {paragraphs.length > 0 && (
+                <div className="absolute right-4 bottom-24 z-30 flex flex-col items-end gap-2 xl:hidden">
+                  <button
+                    type="button"
+                    aria-label={t("carbon_chatbot.report_button")}
+                    onClick={() => setIsMobileReportOpen(true)}
+                    className="flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-4 py-2.5 text-xs font-bold text-gray-700 shadow-lg transition-colors hover:bg-gray-50"
+                  >
+                    <FileText size={16} />
+                    {t("carbon_chatbot.report_button")}
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={t("carbon_chatbot.outline_title")}
+                    onClick={() => setIsMobileOutlineOpen(true)}
+                    className="flex items-center gap-1.5 rounded-full bg-[#ff5a00] px-4 py-2.5 text-xs font-bold text-white shadow-lg shadow-orange-500/30 transition-colors hover:bg-[#e04f00]"
+                  >
+                    <ListTree size={16} />
+                    {reportStats.completedCount}/{reportStats.totalCount}
+                  </button>
+                </div>
+              )}
             </>
           ) : (
             // Info: (20260712 - Luphia) 進入時需一次手勢解鎖加密金鑰(PRF)，之後才由 AI 前置作業回傳招呼詞
@@ -85,17 +120,62 @@ export default function CarbonChatbotPage() {
         </div>
 
         <div className="relative hidden w-[45%] shrink-0 flex-col bg-[#f8fafc] xl:flex">
+          {/* Info: (20260713 - Tzuhan) 報告 artifact:PDF 預覽為預設模式,含章節導軌與目錄抽屜 */}
           <CarbonReportPreview
             session={activeSession}
+            stats={reportStats}
+            activeParagraphId={activeParagraphId}
             onMarkdownChange={handleMarkdownChange}
-            onToggleCompleted={toggleParagraphCompleted}
+            onJumpToParagraph={jumpToParagraph}
             onToggleVerified={toggleParagraphVerified}
           />
 
           {/* Info: (20260708 - Tzuhan) 進度浮窗 */}
-          <ChatProgressWidget progress={activeSession.progress} />
+          <ChatProgressWidget stats={reportStats} />
         </div>
       </div>
+
+      {/* Info: (20260713 - Tzuhan) 行動版章節目錄 Modal;跳段後自動關閉並回到對話 */}
+      {isMobileOutlineOpen && (
+        <OutlineModal
+          paragraphs={paragraphs}
+          stats={reportStats}
+          activeParagraphId={activeParagraphId}
+          onJump={jumpToParagraph}
+          onToggleVerified={toggleParagraphVerified}
+          onClose={() => setIsMobileOutlineOpen(false)}
+        />
+      )}
+
+      {/* Info: (20260713 - Tzuhan) 行動版報告全螢幕檢視:沿用完整 CarbonReportPreview(含工具列/導軌/抽屜/預覽與編輯切換) */}
+      {/* Info: (20260713 - Tzuhan) z-[60] 高於全站 UserHeader(sticky z-50),避免 header 疊在覆蓋層上方 */}
+      {isMobileReportOpen && (
+        <div className="fixed inset-0 z-[60] flex flex-col bg-white xl:hidden">
+          <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+            <span className="text-sm font-bold text-gray-700">
+              {t("carbon_chatbot.report_preview_title")}
+            </span>
+            <button
+              type="button"
+              aria-label={t("carbon_chatbot.close_report")}
+              onClick={() => setIsMobileReportOpen(false)}
+              className="rounded p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+            >
+              <X size={18} />
+            </button>
+          </div>
+          <div className="flex min-h-0 flex-1">
+            <CarbonReportPreview
+              session={activeSession}
+              stats={reportStats}
+              activeParagraphId={activeParagraphId}
+              onMarkdownChange={handleMarkdownChange}
+              onJumpToParagraph={jumpToParagraph}
+              onToggleVerified={toggleParagraphVerified}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/carbon_chatbot/carbon_report_preview.tsx
+++ b/src/components/carbon_chatbot/carbon_report_preview.tsx
@@ -37,6 +37,7 @@ const generateMarkdownFromParagraphs = (
 
   if (!paragraphs || paragraphs.length === 0) {
     return (
+      // ToDo: (20260713 - Luphia) 報告預覽 markdown 表頭為硬編中文，如需多語系報告請改走 t()
       `# ${session.reportData?.title || ""}\n\n## ${session.reportData?.section || ""}\n\n### 溫室氣體排放量摘要\n\n| 類別 (ISO Category) | 來源說明 | 排放量 (tCO2e) |\n| --- | --- | --- |\n` +
       (session.reportData?.categories
         ?.map(

--- a/src/components/carbon_chatbot/carbon_report_preview.tsx
+++ b/src/components/carbon_chatbot/carbon_report_preview.tsx
@@ -1,26 +1,43 @@
 "use client";
 
-import { FileText } from "lucide-react";
-import { IChatSession } from "@/types/carbon_chatbot.types";
-import PdfEditor from "@/components/pdf_tool/pdf_editor";
-import { useState } from "react";
+// Info: (20260713 - Tzuhan) 報告 artifact 檢視:工具列 + 章節導軌 + 目錄抽屜 + PDF 預覽(default)
+// Info: (20260713 - Tzuhan) vibe 模式:段落由 AI 對話生成後即時出現於預覽;點導軌/目錄跳段會將對話目標切至該段
 
-import { CheckCircle2, Circle, AlertCircle } from "lucide-react";
+import { FileText } from "lucide-react";
+import {
+  IChatSession,
+  IReportProgressStats,
+} from "@/types/carbon_chatbot.types";
+import PdfEditor from "@/components/pdf_tool/pdf_editor";
+import { PdfToolViewMode } from "@/constants/pdf_tool";
+import { MOBILE_MEDIA_QUERY } from "@/constants/carbon_chatbot";
+import { buildSectionHeadingByTitle } from "@/constants/carbon_report_outline";
+import { ReportToolbar } from "@/components/carbon_chatbot/report_toolbar";
+import { OutlineRail } from "@/components/carbon_chatbot/outline_rail";
+import { OutlineDrawer } from "@/components/carbon_chatbot/outline_drawer";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "@/i18n/i18n_context";
 
 interface ICarbonReportPreviewProps {
   session?: IChatSession;
+  stats?: IReportProgressStats;
+  activeParagraphId?: string | null;
   onMarkdownChange?: (val: string) => void;
-  onToggleCompleted?: (id: string) => void;
-  onToggleVerified?: (id: string) => void;
+  onJumpToParagraph?: (paragraphId: string) => void;
+  onToggleVerified?: (paragraphId: string) => void;
 }
 
-const generateMarkdownFromParagraphs = (session: IChatSession): string => {
-  const isMock2025 = session.id === "2025";
+// Info: (20260713 - Tzuhan) 渲染全部 33 段:已生成者顯示內容,未生成者顯示灰色佔位區塊,確保跳段永遠有落點且報告骨架一眼可見
+const generateMarkdownFromParagraphs = (
+  session: IChatSession,
+  placeholderHint: string,
+  draftStatusLine: string,
+): string => {
+  const paragraphs = session.reportData?.paragraphs;
 
-  if (!isMock2025 || !session.reportData?.paragraphs) {
+  if (!paragraphs || paragraphs.length === 0) {
     return (
-      `# ${session.reportData?.title || "盤查報告"}\n\n## ${session.reportData?.section || ""}\n\n### 溫室氣體排放量摘要\n\n| 類別 (ISO Category) | 來源說明 | 排放量 (tCO2e) |\n| --- | --- | --- |\n` +
+      `# ${session.reportData?.title || ""}\n\n## ${session.reportData?.section || ""}\n\n### 溫室氣體排放量摘要\n\n| 類別 (ISO Category) | 來源說明 | 排放量 (tCO2e) |\n| --- | --- | --- |\n` +
       (session.reportData?.categories
         ?.map(
           (c) =>
@@ -31,10 +48,15 @@ const generateMarkdownFromParagraphs = (session: IChatSession): string => {
     );
   }
 
-  let md = `# 卡菲卡智慧製造股份有限公司\n## 2025 年度碳盤查報告書 (草案)\n\n<span style="color: gray; font-size: 10px; font-weight: bold; letter-spacing: 0.2em;">REPORT STATUS: DRAFT GENERATED</span>\n\n---\n\n`;
+  // Info: (20260713 - Tzuhan) MarkdownContent 未啟用 rehype-raw,嚴禁在內容層塞原生 HTML;
+  // Info: (20260713 - Tzuhan) 狀態徽章由 ReportToolbar 呈現,文件內僅保留 Markdown 原生語法的草稿聲明(匯出 PDF 亦可見)
+  let md = `# ${session.title}\n\n> _${draftStatusLine}_\n\n---\n\n`;
 
-  session.reportData.paragraphs.forEach((p) => {
-    md += `${p.content}\n\n---\n\n`;
+  paragraphs.forEach((p, index) => {
+    const block =
+      p.content ||
+      `${buildSectionHeadingByTitle(p.title, index)}\n\n> _${placeholderHint}_`;
+    md += `${block}\n\n---\n\n`;
   });
 
   return md;
@@ -42,14 +64,41 @@ const generateMarkdownFromParagraphs = (session: IChatSession): string => {
 
 export default function CarbonReportPreview({
   session = {} as IChatSession,
+  stats = undefined,
+  activeParagraphId = null,
   onMarkdownChange = () => {},
-  onToggleCompleted = () => {},
+  onJumpToParagraph = () => {},
   onToggleVerified = () => {},
 }: ICarbonReportPreviewProps) {
   const { t } = useTranslation();
   const [, setErrorModal] = useState({ isOpen: false, message: "" });
+  const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(false);
+  const previewContainerRef = useRef<HTMLDivElement>(null);
 
   const reportData = session?.reportData;
+  // Info: (20260713 - Tzuhan) useMemo 穩定引用,避免 useEffect 依賴每次 render 變動
+  const paragraphs = useMemo(
+    () => reportData?.paragraphs ?? [],
+    [reportData?.paragraphs],
+  );
+  const hasOutline = paragraphs.length > 0;
+
+  // Info: (20260713 - Tzuhan) 跳段時將 PDF 預覽捲動至該段標題(以段落標題文字定位);未生成段落亦有佔位落點
+  useEffect(() => {
+    if (!activeParagraphId || !previewContainerRef.current) return undefined;
+    const target = paragraphs.find((p) => p.id === activeParagraphId);
+    if (!target) return undefined;
+
+    const timer = setTimeout(() => {
+      const headings =
+        previewContainerRef.current?.querySelectorAll("h3") ?? [];
+      const match = Array.from(headings).find((h) =>
+        h.textContent?.includes(target.title),
+      );
+      match?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 150);
+    return () => clearTimeout(timer);
+  }, [activeParagraphId, paragraphs]);
 
   if (!reportData) {
     return (
@@ -60,71 +109,73 @@ export default function CarbonReportPreview({
     );
   }
 
-  const markdownContent = generateMarkdownFromParagraphs(session);
-  const isMock2025 = session.id === "2025";
+  // Info: (20260713 - Tzuhan) <xl 抽屜為全寬獨占,跳段後自動關閉回到 PDF 落點;xl+ 維持開啟便於連續瀏覽
+  const handleDrawerJump = (paragraphId: string) => {
+    onJumpToParagraph(paragraphId);
+    if (window.matchMedia(MOBILE_MEDIA_QUERY).matches) {
+      setIsDrawerOpen(false);
+    }
+  };
+
+  const markdownContent = generateMarkdownFromParagraphs(
+    session,
+    t("carbon_chatbot.section_placeholder"),
+    t("carbon_chatbot.report_status_draft"),
+  );
 
   return (
     <div className="relative flex h-full w-full flex-1 flex-col border-l border-gray-200 bg-white">
-      {/* Info: (20260708 - Tzuhan) Paragraph Status Tracker UI */}
-      {isMock2025 && reportData.paragraphs && (
-        <div className="border-b border-gray-200 bg-gray-50 px-4 py-3">
-          <h3 className="mb-2 text-sm font-bold text-gray-700">
-            {t("carbon_chatbot.paragraph_tracker_title")}
-          </h3>
-          <div className="flex flex-col gap-2">
-            {reportData.paragraphs.map((p) => (
-              <div
-                key={p.id}
-                className="flex items-center justify-between rounded-md bg-white p-2 text-xs shadow-sm ring-1 ring-gray-200"
-              >
-                <span
-                  className="w-1/3 truncate font-medium text-gray-700"
-                  title={p.title}
-                >
-                  {p.title}
-                </span>
-                <div className="flex items-center gap-4">
-                  <button
-                    onClick={() => onToggleCompleted && onToggleCompleted(p.id)}
-                    className={`flex items-center gap-1 rounded px-2 py-1 transition-colors ${p.isCompleted ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500 hover:bg-gray-200"}`}
-                  >
-                    {p.isCompleted ? (
-                      <CheckCircle2 size={14} />
-                    ) : (
-                      <Circle size={14} />
-                    )}
-                    {p.isCompleted
-                      ? t("carbon_chatbot.status_completed")
-                      : t("carbon_chatbot.status_incomplete")}
-                  </button>
-                  <button
-                    onClick={() => onToggleVerified && onToggleVerified(p.id)}
-                    className={`flex items-center gap-1 rounded px-2 py-1 transition-colors ${p.isVerified ? "bg-blue-100 text-blue-700" : "bg-red-100 text-red-700 hover:bg-red-200"}`}
-                  >
-                    {p.isVerified ? (
-                      <CheckCircle2 size={14} />
-                    ) : (
-                      <AlertCircle size={14} />
-                    )}
-                    {p.isVerified
-                      ? t("carbon_chatbot.status_verified")
-                      : t("carbon_chatbot.status_unverified")}
-                  </button>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
+      {hasOutline && stats && (
+        <ReportToolbar
+          documentName={reportData.documentName}
+          stats={stats}
+          status={session.status}
+          statusColor={session.statusColor}
+          isDrawerOpen={isDrawerOpen}
+          onToggleDrawer={() => setIsDrawerOpen((prev) => !prev)}
+        />
       )}
 
-      <PdfEditor
-        layout="toggle"
-        isEmbedded={true}
-        value={markdownContent}
-        onChange={onMarkdownChange}
-        setErrorModal={setErrorModal}
-        storageKey={`chatbot_draft_${session.id}`}
-      />
+      <div className="flex min-h-0 flex-1">
+        {/* Info: (20260713 - Tzuhan) <xl 且抽屜開啟時隱藏導軌,讓目錄獨占畫面 */}
+        {hasOutline && (
+          <OutlineRail
+            paragraphs={paragraphs}
+            activeParagraphId={activeParagraphId}
+            onJump={onJumpToParagraph}
+            className={isDrawerOpen ? "hidden xl:flex" : ""}
+          />
+        )}
+
+        {hasOutline && isDrawerOpen && (
+          <OutlineDrawer
+            paragraphs={paragraphs}
+            activeParagraphId={activeParagraphId}
+            onJump={handleDrawerJump}
+            onToggleVerified={onToggleVerified}
+            onClose={() => setIsDrawerOpen(false)}
+          />
+        )}
+
+        {/* Info: (20260713 - Tzuhan) <xl 且抽屜開啟時隱藏 PDF 區,避免與全寬目錄擠壓並排 */}
+        <div
+          ref={previewContainerRef}
+          className={`min-w-0 flex-1 overflow-y-auto ${
+            isDrawerOpen ? "hidden xl:block" : ""
+          }`}
+        >
+          <PdfEditor
+            layout="toggle"
+            isEmbedded={true}
+            defaultViewMode={PdfToolViewMode.PREVIEW}
+            contentVariant="compact"
+            value={markdownContent}
+            onChange={onMarkdownChange}
+            setErrorModal={setErrorModal}
+            storageKey={`chatbot_draft_${session.id}`}
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/carbon_chatbot/chat_progress_widget.tsx
+++ b/src/components/carbon_chatbot/chat_progress_widget.tsx
@@ -1,9 +1,13 @@
-export interface IChatProgressWidgetProps {
-  progress: number;
-}
+// Info: (20260713 - Tzuhan) 進度浮窗:完成/查核雙軌顯示,數據來源為 reportStats(實際段落統計)
+
+import { IReportProgressStats } from "@/types/carbon_chatbot.types";
 import { useTranslation } from "@/i18n/i18n_context";
 
-export function ChatProgressWidget({ progress }: IChatProgressWidgetProps) {
+export interface IChatProgressWidgetProps {
+  stats: IReportProgressStats;
+}
+
+export function ChatProgressWidget({ stats }: IChatProgressWidgetProps) {
   const { t } = useTranslation();
   return (
     <div className="absolute right-10 bottom-10 z-20 flex w-80 items-center gap-5 rounded-2xl bg-[#1e293b] p-5 text-white shadow-2xl">
@@ -23,14 +27,30 @@ export function ChatProgressWidget({ progress }: IChatProgressWidgetProps) {
         </svg>
       </div>
       <div className="min-w-0 flex-1">
-        <div className="mb-2.5 flex justify-between text-xs font-bold tracking-wide text-slate-300">
+        <div className="mb-2 flex justify-between text-xs font-bold tracking-wide text-slate-300">
           <span>{t("carbon_chatbot.report_progress")}</span>
-          <span className="text-white">{progress}%</span>
+          <span className="text-white">
+            {stats.completedCount}/{stats.totalCount} · {stats.completedPercent}
+            %
+          </span>
         </div>
         <div className="h-2 overflow-hidden rounded-full border border-white/5 bg-slate-800">
           <div
             className="h-full rounded-full bg-gradient-to-r from-orange-500 to-[#ff5a00] shadow-[0_0_10px_rgba(255,90,0,0.5)] transition-all duration-1000 ease-out"
-            style={{ width: `${progress}%` }}
+            style={{ width: `${stats.completedPercent}%` }}
+          ></div>
+        </div>
+        {/* Info: (20260713 - Tzuhan) 次軌:人工查核簽核進度(零信任:AI 產出須經人工覆核) */}
+        <div className="mt-2 mb-1 flex justify-between text-[11px] font-bold tracking-wide text-slate-400">
+          <span>{t("carbon_chatbot.verified_progress")}</span>
+          <span className="text-slate-200">
+            {stats.verifiedCount}/{stats.totalCount} · {stats.verifiedPercent}%
+          </span>
+        </div>
+        <div className="h-1.5 overflow-hidden rounded-full border border-white/5 bg-slate-800">
+          <div
+            className="h-full rounded-full bg-blue-500 transition-all duration-1000 ease-out"
+            style={{ width: `${stats.verifiedPercent}%` }}
           ></div>
         </div>
       </div>

--- a/src/components/carbon_chatbot/outline_drawer.tsx
+++ b/src/components/carbon_chatbot/outline_drawer.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+// Info: (20260713 - Tzuhan) 章節目錄抽屜(桌面):標頭 + 共用 OutlineTree;點段落跳轉對話目標
+// Info: (20260713 - Tzuhan) vibe 模式:isCompleted 由系統依生成狀態判定(唯讀顯示),僅 isVerified(人工簽核)可手動切換
+
+import { X } from "lucide-react";
+import { IReportParagraph } from "@/types/carbon_chatbot.types";
+import { OutlineTree } from "@/components/carbon_chatbot/outline_tree";
+import { useTranslation } from "@/i18n/i18n_context";
+
+interface IOutlineDrawerProps {
+  paragraphs: IReportParagraph[];
+  activeParagraphId: string | null;
+  onJump: (paragraphId: string) => void;
+  onToggleVerified: (paragraphId: string) => void;
+  onClose: () => void;
+}
+
+export function OutlineDrawer({
+  paragraphs,
+  activeParagraphId,
+  onJump,
+  onToggleVerified,
+  onClose,
+}: IOutlineDrawerProps) {
+  const { t } = useTranslation();
+
+  return (
+    // Info: (20260713 - Tzuhan) <xl 抽屜全寬獨占(行動版不與 PDF 並排);xl+ 固定 240px 側欄
+    <div className="flex w-full shrink-0 flex-col border-r border-gray-200 bg-white xl:w-60">
+      <div className="flex items-center justify-between border-b border-gray-200 px-3 py-2.5">
+        <span className="text-xs font-bold text-gray-700">
+          {t("carbon_chatbot.outline_title")} ({paragraphs.length})
+        </span>
+        <button
+          type="button"
+          aria-label={t("carbon_chatbot.close_outline")}
+          onClick={onClose}
+          className="rounded p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      <OutlineTree
+        paragraphs={paragraphs}
+        activeParagraphId={activeParagraphId}
+        onJump={onJump}
+        onToggleVerified={onToggleVerified}
+      />
+    </div>
+  );
+}

--- a/src/components/carbon_chatbot/outline_modal.tsx
+++ b/src/components/carbon_chatbot/outline_modal.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+// Info: (20260713 - Tzuhan) 行動版(<xl)章節目錄 Modal:右欄預覽於窄螢幕隱藏,此為 33 段大綱與查核進度的唯一入口
+// Info: (20260713 - Tzuhan) 點段落 = 跳轉對話目標並關閉 Modal(行動版以對話為主視圖)
+
+import { X } from "lucide-react";
+import {
+  IReportParagraph,
+  IReportProgressStats,
+} from "@/types/carbon_chatbot.types";
+import { OutlineTree } from "@/components/carbon_chatbot/outline_tree";
+import { useTranslation } from "@/i18n/i18n_context";
+
+interface IOutlineModalProps {
+  paragraphs: IReportParagraph[];
+  stats: IReportProgressStats;
+  activeParagraphId: string | null;
+  onJump: (paragraphId: string) => void;
+  onToggleVerified: (paragraphId: string) => void;
+  onClose: () => void;
+}
+
+export function OutlineModal({
+  paragraphs,
+  stats,
+  activeParagraphId,
+  onJump,
+  onToggleVerified,
+  onClose,
+}: IOutlineModalProps) {
+  const { t } = useTranslation();
+
+  const handleJump = (paragraphId: string) => {
+    onJump(paragraphId);
+    onClose();
+  };
+
+  return (
+    // Info: (20260713 - Tzuhan) z-[70] 高於全站 UserHeader(z-50)與行動版報告覆蓋層(z-[60])
+    <div
+      className="fixed inset-0 z-[70] flex items-center justify-center p-4 xl:hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-label={t("carbon_chatbot.outline_title")}
+    >
+      {/* Info: (20260713 - Tzuhan) 背景遮罩用原生 button,滿足鍵盤操作與 a11y 規範 */}
+      <button
+        type="button"
+        aria-label={t("carbon_chatbot.close_outline")}
+        onClick={onClose}
+        className="absolute inset-0 cursor-default bg-black/40"
+      />
+      <div className="relative flex max-h-[80vh] w-full max-w-md flex-col overflow-hidden rounded-2xl bg-white shadow-2xl">
+        <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+          <span className="text-sm font-bold text-gray-700">
+            {t("carbon_chatbot.outline_title")} ({paragraphs.length})
+          </span>
+          <button
+            type="button"
+            aria-label={t("carbon_chatbot.close_outline")}
+            onClick={onClose}
+            className="rounded p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Info: (20260713 - Tzuhan) 雙軌進度:與桌面工具列膠囊同一資料來源(reportStats) */}
+        <div className="flex items-center gap-3 border-b border-gray-100 bg-gray-50 px-4 py-2.5 text-xs">
+          <span className="font-medium text-green-700">
+            {t("carbon_chatbot.completed_short")} {stats.completedCount}/
+            {stats.totalCount}
+          </span>
+          <span className="text-gray-300">|</span>
+          <span className="font-medium text-blue-700">
+            {t("carbon_chatbot.verified_short")} {stats.verifiedCount}/
+            {stats.totalCount}
+          </span>
+          <span className="relative ml-auto inline-block h-1.5 w-24 overflow-hidden rounded-full bg-gray-200">
+            <span
+              className="absolute inset-y-0 left-0 rounded-full bg-green-400 transition-all duration-500"
+              style={{ width: `${stats.completedPercent}%` }}
+            />
+            <span
+              className="absolute inset-y-0 left-0 rounded-full bg-blue-500 transition-all duration-500"
+              style={{ width: `${stats.verifiedPercent}%` }}
+            />
+          </span>
+        </div>
+
+        <OutlineTree
+          paragraphs={paragraphs}
+          activeParagraphId={activeParagraphId}
+          onJump={handleJump}
+          onToggleVerified={onToggleVerified}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/carbon_chatbot/outline_rail.tsx
+++ b/src/components/carbon_chatbot/outline_rail.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+// Info: (20260713 - Tzuhan) 常駐章節導軌:33 個狀態點依章分組,hover 顯示標題,點擊跳段
+// Info: (20260713 - Tzuhan) 狀態色:藍=已查核、綠=已完成、橘框=進行中(對話目標)、灰框=未開始
+
+import { IReportParagraph } from "@/types/carbon_chatbot.types";
+import { CARBON_REPORT_CHAPTERS } from "@/constants/carbon_report_outline";
+import { useTranslation } from "@/i18n/i18n_context";
+
+interface IOutlineRailProps {
+  paragraphs: IReportParagraph[];
+  activeParagraphId: string | null;
+  onJump: (paragraphId: string) => void;
+  className?: string;
+}
+
+const dotClassName = (
+  paragraph: IReportParagraph,
+  isActive: boolean,
+): string => {
+  const base =
+    "h-2.5 w-2.5 rounded-full transition-all duration-200 hover:scale-125";
+  const ring = isActive ? " ring-2 ring-[#ff5a00] ring-offset-1" : "";
+  if (paragraph.isVerified) return `${base} bg-blue-500${ring}`;
+  if (paragraph.isCompleted) return `${base} bg-green-500${ring}`;
+  if (isActive) return `${base} border-2 border-[#ff5a00] bg-white`;
+  return `${base} border border-gray-300 bg-white`;
+};
+
+export function OutlineRail({
+  paragraphs,
+  activeParagraphId,
+  onJump,
+  className = "",
+}: IOutlineRailProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className={`flex w-11 shrink-0 flex-col items-center gap-3 overflow-y-auto border-r border-gray-200 bg-gray-50 py-3 ${className}`}
+    >
+      {CARBON_REPORT_CHAPTERS.map((chapter) => {
+        const chapterParagraphs = paragraphs.filter(
+          (p) => p.chapterId === chapter.id,
+        );
+        if (chapterParagraphs.length === 0) return null;
+        return (
+          <div
+            key={chapter.id}
+            className="flex flex-col items-center gap-1.5"
+            title={chapter.title}
+          >
+            {chapterParagraphs.map((p) => (
+              <button
+                key={p.id}
+                type="button"
+                aria-label={`${p.title} ${t("carbon_chatbot.jump_aria_label")}`}
+                title={p.title}
+                onClick={() => onJump(p.id)}
+                className={dotClassName(p, p.id === activeParagraphId)}
+              />
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/carbon_chatbot/outline_tree.tsx
+++ b/src/components/carbon_chatbot/outline_tree.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+// Info: (20260713 - Tzuhan) 章節樹(11 章可折疊 + 段落狀態/簽核):桌面 OutlineDrawer 與行動版 OutlineModal 共用
+
+import { useState } from "react";
+import {
+  ChevronDown,
+  ChevronRight,
+  CheckCircle2,
+  Circle,
+  CircleDot,
+  ShieldCheck,
+  Database,
+} from "lucide-react";
+import { IReportParagraph } from "@/types/carbon_chatbot.types";
+import { CARBON_REPORT_CHAPTERS } from "@/constants/carbon_report_outline";
+import { useTranslation } from "@/i18n/i18n_context";
+
+interface IOutlineTreeProps {
+  paragraphs: IReportParagraph[];
+  activeParagraphId: string | null;
+  onJump: (paragraphId: string) => void;
+  onToggleVerified: (paragraphId: string) => void;
+}
+
+const statusIcon = (paragraph: IReportParagraph, isActive: boolean) => {
+  if (paragraph.isCompleted)
+    return <CheckCircle2 size={14} className="shrink-0 text-green-600" />;
+  if (isActive)
+    return <CircleDot size={14} className="shrink-0 text-[#ff5a00]" />;
+  return <Circle size={14} className="shrink-0 text-gray-300" />;
+};
+
+export function OutlineTree({
+  paragraphs,
+  activeParagraphId,
+  onJump,
+  onToggleVerified,
+}: IOutlineTreeProps) {
+  const { t } = useTranslation();
+  const activeChapterId = paragraphs.find(
+    (p) => p.id === activeParagraphId,
+  )?.chapterId;
+  const [expandedChapters, setExpandedChapters] = useState<
+    Record<string, boolean>
+  >(activeChapterId ? { [activeChapterId]: true } : {});
+
+  const toggleChapter = (chapterId: string) =>
+    setExpandedChapters((prev) => ({
+      ...prev,
+      [chapterId]: !prev[chapterId],
+    }));
+
+  return (
+    // Info: (20260713 - Tzuhan) min-h-0 讓 flex 子元素可收縮,行動版 Modal 內才能正確捲動
+    <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-2">
+      {CARBON_REPORT_CHAPTERS.map((chapter) => {
+        const chapterParagraphs = paragraphs.filter(
+          (p) => p.chapterId === chapter.id,
+        );
+        if (chapterParagraphs.length === 0) return null;
+        const completedCount = chapterParagraphs.filter(
+          (p) => p.isCompleted,
+        ).length;
+        const isExpanded = Boolean(expandedChapters[chapter.id]);
+
+        return (
+          <div key={chapter.id} className="mb-1">
+            <button
+              type="button"
+              onClick={() => toggleChapter(chapter.id)}
+              className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50"
+            >
+              {isExpanded ? (
+                <ChevronDown size={13} className="shrink-0 text-gray-400" />
+              ) : (
+                <ChevronRight size={13} className="shrink-0 text-gray-400" />
+              )}
+              <span className="min-w-0 flex-1 truncate" title={chapter.title}>
+                {chapter.title}
+              </span>
+              <span
+                className={`shrink-0 text-[11px] ${
+                  completedCount === chapterParagraphs.length
+                    ? "text-green-600"
+                    : "text-gray-400"
+                }`}
+              >
+                {completedCount}/{chapterParagraphs.length}
+              </span>
+            </button>
+
+            {isExpanded && (
+              <div className="ml-4 flex flex-col gap-0.5 border-l border-gray-100 pl-2">
+                {chapterParagraphs.map((p) => {
+                  const isActive = p.id === activeParagraphId;
+                  return (
+                    <div
+                      key={p.id}
+                      className={`group flex items-center gap-1.5 rounded-md px-1.5 py-1 text-xs transition-colors ${
+                        isActive
+                          ? "bg-orange-50 text-[#ff5a00]"
+                          : "text-gray-600 hover:bg-gray-50"
+                      }`}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => onJump(p.id)}
+                        className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+                        title={p.title}
+                      >
+                        {statusIcon(p, isActive)}
+                        <span className="min-w-0 flex-1 truncate">
+                          {p.title}
+                        </span>
+                      </button>
+
+                      {/* Info: (20260713 - Tzuhan) 數據段落標記:數字由後端決定論管線勾稽,非 LLM 產出 */}
+                      {p.isDataDriven && (
+                        <span title={t("carbon_chatbot.data_driven_badge")}>
+                          <Database
+                            size={12}
+                            className="shrink-0 text-teal-600"
+                          />
+                        </span>
+                      )}
+
+                      <button
+                        type="button"
+                        disabled={!p.isCompleted}
+                        onClick={() => onToggleVerified(p.id)}
+                        title={
+                          p.isVerified
+                            ? t("carbon_chatbot.status_verified")
+                            : t("carbon_chatbot.status_unverified")
+                        }
+                        className={`shrink-0 rounded p-0.5 transition-colors ${
+                          p.isVerified
+                            ? "text-blue-600 hover:bg-blue-50"
+                            : p.isCompleted
+                              ? "text-gray-300 hover:bg-gray-100 hover:text-blue-500"
+                              : "cursor-not-allowed text-gray-200"
+                        }`}
+                      >
+                        <ShieldCheck size={13} />
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/carbon_chatbot/report_toolbar.tsx
+++ b/src/components/carbon_chatbot/report_toolbar.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+// Info: (20260713 - Tzuhan) 報告工具列:文件名 + 完成/查核雙軌進度膠囊 + 章節目錄開關
+
+import { FileText, ListTree } from "lucide-react";
+import { IReportProgressStats } from "@/types/carbon_chatbot.types";
+import { useTranslation } from "@/i18n/i18n_context";
+
+interface IReportToolbarProps {
+  documentName: string;
+  stats: IReportProgressStats;
+  isDrawerOpen: boolean;
+  onToggleDrawer: () => void;
+  // Info: (20260713 - Tzuhan) 報告狀態徽章(取代舊 Markdown 內嵌 HTML 的狀態列)
+  status?: string;
+  statusColor?: string;
+}
+
+export function ReportToolbar({
+  documentName,
+  stats,
+  isDrawerOpen,
+  onToggleDrawer,
+  status = undefined,
+  statusColor = undefined,
+}: IReportToolbarProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex items-center gap-3 border-b border-gray-200 bg-white px-4 py-2.5">
+      <FileText size={16} className="shrink-0 text-gray-400" />
+      <span
+        className="min-w-0 truncate text-xs font-bold text-gray-700"
+        title={documentName}
+      >
+        {documentName}
+      </span>
+      {status && (
+        <span
+          className={`shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium ${statusColor ?? "bg-gray-100 text-gray-500"}`}
+        >
+          {status}
+        </span>
+      )}
+
+      {/* Info: (20260713 - Tzuhan) 進度膠囊:點擊也可展開章節目錄 */}
+      <button
+        type="button"
+        onClick={onToggleDrawer}
+        className="ml-auto flex shrink-0 items-center gap-2 rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-xs transition-colors hover:bg-gray-100"
+        title={t("carbon_chatbot.outline_title")}
+      >
+        <span className="font-medium text-green-700">
+          {t("carbon_chatbot.completed_short")} {stats.completedCount}/
+          {stats.totalCount}
+        </span>
+        <span className="text-gray-300">|</span>
+        <span className="font-medium text-blue-700">
+          {t("carbon_chatbot.verified_short")} {stats.verifiedCount}/
+          {stats.totalCount}
+        </span>
+        <span className="relative inline-block h-1.5 w-16 overflow-hidden rounded-full bg-gray-200">
+          <span
+            className="absolute inset-y-0 left-0 rounded-full bg-green-400 transition-all duration-500"
+            style={{ width: `${stats.completedPercent}%` }}
+          />
+          <span
+            className="absolute inset-y-0 left-0 rounded-full bg-blue-500 transition-all duration-500"
+            style={{ width: `${stats.verifiedPercent}%` }}
+          />
+        </span>
+      </button>
+
+      <button
+        type="button"
+        onClick={onToggleDrawer}
+        className={`flex shrink-0 items-center gap-1 rounded-lg border px-2.5 py-1 text-xs font-medium transition-colors ${
+          isDrawerOpen
+            ? "border-[#ff5a00] bg-orange-50 text-[#ff5a00]"
+            : "border-gray-200 bg-white text-gray-600 hover:bg-gray-50"
+        }`}
+      >
+        <ListTree size={14} />
+        {t("carbon_chatbot.outline_button")}
+      </button>
+    </div>
+  );
+}

--- a/src/components/common/markdown_content.tsx
+++ b/src/components/common/markdown_content.tsx
@@ -78,18 +78,31 @@ const AsyncLariaImage = ({
   );
 };
 
+// Info: (20260713 - Tzuhan) 字級變體:document 為 A4 文件級(預設,匯出 PDF 用);compact 為嵌入式 UI 級(與 app text-sm 基準協調)
+export type MarkdownContentVariant = "document" | "compact";
+
 interface IMarkdownContentProps {
   content: string;
   theme?: "dark" | "light";
+  variant?: MarkdownContentVariant;
   onContentChange?: (newContent: string) => void;
 }
 
 const MarkdownContent: FC<IMarkdownContentProps> = ({
   content,
   theme = "dark",
+  variant = "document",
   onContentChange = () => {},
 }) => {
   const isDark = theme === "dark";
+  // Info: (20260713 - Tzuhan) compact 全面降一級,body 固定 text-sm;以明確 class 輸出,避免與外層 CSS 覆寫打架
+  const isCompact = variant === "compact";
+  const h1Size = isCompact ? "text-xl" : "text-2xl";
+  const h2Size = isCompact ? "text-lg" : "text-xl";
+  const h3Size = isCompact ? "text-base" : "text-lg";
+  const h4Size = isCompact ? "text-sm" : "text-base";
+  const h5Size = isCompact ? "text-xs" : "text-sm";
+  const bodySize = isCompact ? "text-sm" : "";
   const textColor = isDark ? "text-[#ffffff]" : "text-[#111827]";
   const secondaryTextColor = isDark ? "text-[#E0E0E0]" : "text-[#374151]";
   const linkColor = isDark ? "text-[#64B5F6]" : "text-[#2563eb]";
@@ -104,7 +117,7 @@ const MarkdownContent: FC<IMarkdownContentProps> = ({
     () => ({
       h1: ({ children, ...props }: ComponentPropsWithoutRef<"h1">) => (
         <h1
-          className={`mt-5 mb-3 flex items-center gap-2 border-b ${borderColor} pb-2 text-2xl font-bold ${textColor}`}
+          className={`mt-5 mb-3 flex items-center gap-2 border-b ${borderColor} pb-2 ${h1Size} font-bold ${textColor}`}
           {...props}
         >
           {children}
@@ -112,7 +125,7 @@ const MarkdownContent: FC<IMarkdownContentProps> = ({
       ),
       h2: ({ children, ...props }: ComponentPropsWithoutRef<"h2">) => (
         <h2
-          className={`mt-4 mb-2 flex items-center gap-2 text-xl font-bold ${textColor}`}
+          className={`mt-4 mb-2 flex items-center gap-2 ${h2Size} font-bold ${textColor}`}
           {...props}
         >
           <span
@@ -122,13 +135,16 @@ const MarkdownContent: FC<IMarkdownContentProps> = ({
         </h2>
       ),
       h3: ({ children, ...props }: ComponentPropsWithoutRef<"h3">) => (
-        <h3 className={`mt-3 mb-1.5 text-lg font-bold ${textColor}`} {...props}>
+        <h3
+          className={`mt-3 mb-1.5 ${h3Size} font-bold ${textColor}`}
+          {...props}
+        >
           {children}
         </h3>
       ),
       h4: ({ children, ...props }: ComponentPropsWithoutRef<"h4">) => (
         <h4
-          className={`mt-3 mb-1.5 text-base font-semibold ${textColor}`}
+          className={`mt-3 mb-1.5 ${h4Size} font-semibold ${textColor}`}
           {...props}
         >
           {children}
@@ -136,14 +152,17 @@ const MarkdownContent: FC<IMarkdownContentProps> = ({
       ),
       h5: ({ children, ...props }: ComponentPropsWithoutRef<"h5">) => (
         <h5
-          className={`mt-2 mb-1 text-sm font-semibold ${textColor}`}
+          className={`mt-2 mb-1 ${h5Size} font-semibold ${textColor}`}
           {...props}
         >
           {children}
         </h5>
       ),
       h6: ({ children, ...props }: ComponentPropsWithoutRef<"h6">) => (
-        <h6 className={`mt-2 mb-1 text-sm font-medium ${textColor}`} {...props}>
+        <h6
+          className={`mt-2 mb-1 ${h5Size} font-medium ${textColor}`}
+          {...props}
+        >
           {children}
         </h6>
       ),
@@ -153,13 +172,16 @@ const MarkdownContent: FC<IMarkdownContentProps> = ({
         </strong>
       ),
       ul: ({ children, ...props }: ComponentPropsWithoutRef<"ul">) => (
-        <ul className={`mb-3 list-disc pl-6 ${secondaryTextColor}`} {...props}>
+        <ul
+          className={`mb-3 list-disc pl-6 ${bodySize} ${secondaryTextColor}`}
+          {...props}
+        >
           {children}
         </ul>
       ),
       ol: ({ children, ...props }: ComponentPropsWithoutRef<"ol">) => (
         <ol
-          className={`mb-3 list-decimal pl-6 ${secondaryTextColor}`}
+          className={`mb-3 list-decimal pl-6 ${bodySize} ${secondaryTextColor}`}
           {...props}
         >
           {children}
@@ -176,7 +198,10 @@ const MarkdownContent: FC<IMarkdownContentProps> = ({
         );
       },
       p: ({ children, ...props }: ComponentPropsWithoutRef<"p">) => (
-        <p className={`mb-3 leading-relaxed ${secondaryTextColor}`} {...props}>
+        <p
+          className={`mb-3 leading-relaxed ${bodySize} ${secondaryTextColor}`}
+          {...props}
+        >
           {children}
         </p>
       ),
@@ -195,7 +220,7 @@ const MarkdownContent: FC<IMarkdownContentProps> = ({
         ...props
       }: ComponentPropsWithoutRef<"blockquote">) => (
         <blockquote
-          className={`my-3 rounded-r-lg border-l-4 border-[#FF9800] ${blockquoteBg} px-4 py-3 italic ${blockquoteText} break-inside-avoid print:break-inside-avoid`}
+          className={`my-3 rounded-r-lg border-l-4 border-[#FF9800] ${blockquoteBg} px-4 py-3 italic ${bodySize} ${blockquoteText} break-inside-avoid print:break-inside-avoid`}
           {...props}
         >
           {children}
@@ -329,6 +354,12 @@ const MarkdownContent: FC<IMarkdownContentProps> = ({
       isDark,
       content,
       onContentChange,
+      h1Size,
+      h2Size,
+      h3Size,
+      h4Size,
+      h5Size,
+      bodySize,
     ],
   );
 

--- a/src/components/pdf_tool/pdf_editor.tsx
+++ b/src/components/pdf_tool/pdf_editor.tsx
@@ -11,7 +11,10 @@ import {
   Sparkles,
   X as XIcon,
 } from "lucide-react";
-import { MarkdownContent } from "@/components/common/markdown_content";
+import {
+  MarkdownContent,
+  MarkdownContentVariant,
+} from "@/components/common/markdown_content";
 import { useTranslation } from "@/i18n/i18n_context";
 import Image from "next/image";
 import { request } from "@/lib/utils/request";
@@ -44,6 +47,10 @@ interface IPdfEditorProps {
   value?: string;
   onChange?: (val: string) => void;
   storageKey?: string;
+  // Info: (20260713 - Tzuhan) 初始檢視模式;未指定時維持 EDIT 以相容既有呼叫點
+  defaultViewMode?: PdfToolViewMode;
+  // Info: (20260713 - Tzuhan) 預覽內容字級變體;嵌入式場景(如 carbon_chatbot)傳 compact 與 app UI 協調
+  contentVariant?: MarkdownContentVariant;
 }
 
 export default function PdfEditor({
@@ -53,6 +60,8 @@ export default function PdfEditor({
   value = undefined,
   onChange = undefined,
   storageKey = STORAGE_KEY,
+  defaultViewMode = PdfToolViewMode.EDIT,
+  contentVariant = "document",
 }: IPdfEditorProps) {
   const { t } = useTranslation();
 
@@ -62,9 +71,7 @@ export default function PdfEditor({
   const [markdownContext, setMarkdownContext] =
     useState<string>(DEFAULT_CONTENT);
   const [isGenerating, setIsGenerating] = useState<boolean>(false);
-  const [viewMode, setViewMode] = useState<PdfToolViewMode>(
-    PdfToolViewMode.EDIT,
-  );
+  const [viewMode, setViewMode] = useState<PdfToolViewMode>(defaultViewMode);
 
   const [isAiProcessing, setIsAiProcessing] = useState<boolean>(false);
 
@@ -594,6 +601,7 @@ export default function PdfEditor({
                   <div className="max-w-none text-[#374151]">
                     <MarkdownContent
                       content={markdownContext}
+                      variant={contentVariant}
                       onContentChange={(val) => {
                         if (value !== undefined && onChange) {
                           onChange(val);

--- a/src/constants/carbon_chatbot.mock.ts
+++ b/src/constants/carbon_chatbot.mock.ts
@@ -4,9 +4,50 @@
 import {
   ChatRoleEnum,
   IChatSession,
+  IReportParagraph,
   SessionStatusEnum,
 } from "@/types/carbon_chatbot.types";
 import { DEFAULT_SESSION_ID } from "@/constants/carbon_chatbot";
+import {
+  CARBON_REPORT_OUTLINE,
+  buildSectionHeading,
+} from "@/constants/carbon_report_outline";
+
+// Info: (20260713 - Tzuhan) Demo 用已生成段落內容(vibe 模式:內容由 AI 生成後 isCompleted 自動為 true,isVerified 一律待人工簽核)
+const DEMO_PARAGRAPH_BODIES: Record<
+  string,
+  { body: string; isVerified: boolean }
+> = {
+  "ch2-1": {
+    body: "本報告選定 **2025年** 作為溫室氣體盤查之基準年。此年度資料將作為未來減碳目標設定與績效追蹤的基礎。當公司發生實體併購、分拆或計算方法重大改變,且影響超過總排放量 5% 時,將觸發基準年數據重算。",
+    isVerified: true,
+  },
+  "ch1-5": {
+    body: "採用**營運控制權法**(Operational Control Approach)涵蓋總部大樓與新竹廠區,與財務合併報表邊界一致。排除海外銷售辦事處,因其排放量占比小於 1%。",
+    isVerified: false,
+  },
+  "ch2-2": {
+    body: "- **範疇一 (Scope 1)**: 公務車用油(汽油 5,000 公升)、緊急發電機用柴油(500 公升)。\n- **範疇二 (Scope 2)**: 辦公室與廠區外購電力(約 1,200,000 度)。",
+    isVerified: false,
+  },
+};
+
+// Info: (20260713 - Tzuhan) 由標準大綱展開 33 段初始狀態;未生成段落 content 為空字串
+const buildInitialParagraphs = (): IReportParagraph[] =>
+  CARBON_REPORT_OUTLINE.map((section, index) => {
+    const heading = buildSectionHeading(section, index);
+    const demo = DEMO_PARAGRAPH_BODIES[section.id];
+    return {
+      id: section.id,
+      chapterId: section.chapterId,
+      code: section.code,
+      title: `${section.code} ${section.title}`,
+      content: demo ? `${heading}\n\n${demo.body}` : "",
+      isCompleted: Boolean(demo),
+      isVerified: demo?.isVerified ?? false,
+      isDataDriven: section.isDataDriven,
+    };
+  });
 
 export const INITIAL_SESSIONS: Record<string, IChatSession> = {
   [DEFAULT_SESSION_ID]: {
@@ -15,8 +56,8 @@ export const INITIAL_SESSIONS: Record<string, IChatSession> = {
     time: "今天",
     status: SessionStatusEnum.IN_PROGRESS,
     statusColor: "text-orange-500 bg-orange-100",
-    progress: 10,
-    currentStep: "組織邊界鑑定",
+    progress: 9,
+    currentStep: "1.4 氣候治理架構與職責",
     // Info: (20260712 - Luphia) 招呼詞改由進入 channel 後 AI 前置作業產生並經 Centrifugo 回傳，故初始為空
     messages: [],
     reportData: {
@@ -37,32 +78,8 @@ export const INITIAL_SESSIONS: Record<string, IChatSession> = {
           emissions: 594.0,
         },
       ],
-      paragraphs: [
-        {
-          id: "p1",
-          title: "### SECTION 01: 基準年設定",
-          content:
-            "### SECTION 01: 基準年設定\n\n本報告選定 **2025年** 作為溫室氣體盤查之基準年。此年度資料將作為未來減碳目標設定與績效追蹤的基礎。",
-          isCompleted: true,
-          isVerified: true,
-        },
-        {
-          id: "p2",
-          title: "### SECTION 02: 組織邊界鑑定",
-          content:
-            "### SECTION 02: 組織邊界鑑定\n\n採用**營運控制權法**（Operational Control Approach）涵蓋總部大樓與新竹廠區。排除海外銷售辦事處，因其排放量占比小於 1%。",
-          isCompleted: true,
-          isVerified: false,
-        },
-        {
-          id: "p3",
-          title: "### SECTION 03: 排放源與活動數據",
-          content:
-            "### SECTION 03: 排放源與活動數據\n\n- **範疇一 (Category 1)**: 公務車用油 (汽油 5,000 公升)、緊急發電機用柴油 (500 公升)。\n- **範疇二 (Category 2)**: 辦公室與廠區外購電力 (約 1,200,000 度)。",
-          isCompleted: false,
-          isVerified: false,
-        },
-      ],
+      // Info: (20260713 - Tzuhan) 33 段標準大綱展開,含 3 段 demo 已生成內容
+      paragraphs: buildInitialParagraphs(),
       totalEmissions: 679.42,
     },
   },

--- a/src/constants/carbon_chatbot.ts
+++ b/src/constants/carbon_chatbot.ts
@@ -51,3 +51,6 @@ export const CARBON_INVENTORY_STEP_ORDER: CarbonInventoryStep[] = [
 
 // Info: (20260712 - Luphia) 結構化狀態 schema 版本（便於未來遷移）
 export const CARBON_INVENTORY_STATE_VERSION = 1;
+
+// Info: (20260713 - Tzuhan) 行動版斷點判斷(對齊 Tailwind xl = 1280px):< xl 時目錄/報告採獨占畫面呈現
+export const MOBILE_MEDIA_QUERY = "(max-width: 1279px)";

--- a/src/constants/carbon_report_outline.ts
+++ b/src/constants/carbon_report_outline.ts
@@ -1,0 +1,342 @@
+// Info: (20260713 - Tzuhan) 碳盤查報告書標準章節大綱(IFRS S1/S2 對齊),共 11 章 33 段
+// Info: (20260713 - Tzuhan) guidance 為各段落的撰寫目標,供 AI 引導對話時注入 prompt;isDataDriven 標記數據段落(數字必須來自後端決定論管線,LLM 只排版不算數)
+
+export interface ICarbonReportChapter {
+  id: string;
+  title: string;
+}
+
+export interface ICarbonReportSection {
+  id: string;
+  chapterId: string;
+  code: string;
+  title: string;
+  guidance: string;
+  isDataDriven: boolean;
+}
+
+export const CARBON_REPORT_CHAPTERS: ICarbonReportChapter[] = [
+  { id: "ch1", title: "第一章 組織與治理概況" },
+  { id: "ch2", title: "第二章 報告邊界" },
+  { id: "ch3", title: "第三章 溫室氣體排放" },
+  { id: "ch4", title: "第四章 數據品質管理" },
+  { id: "ch5", title: "第五章 溫室氣體減量措施及內部績效追蹤" },
+  { id: "ch6", title: "第六章 溫室氣體資訊管理及盤查作業" },
+  { id: "ch7", title: "第七章 溫室氣體內部查證及定期審查" },
+  { id: "ch8", title: "第八章 溫室氣體盤查資訊管理及記錄保存" },
+  { id: "ch9", title: "第九章 查證" },
+  { id: "ch10", title: "第十章 報告之責任、目的與格式" },
+  { id: "ch11", title: "第十一章 參考文獻" },
+];
+
+export const CARBON_REPORT_OUTLINE: ICarbonReportSection[] = [
+  {
+    id: "ch1-intro",
+    chapterId: "ch1",
+    code: "第一章",
+    title: "組織與治理概況(導論)",
+    guidance:
+      "闡述組織如何將氣候變遷視為董事會層級的重大財務風險與機會,並聲明報告編寫符合 IFRS S1/S2 與相應量化標準。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch1-1",
+    chapterId: "ch1",
+    code: "1.1",
+    title: "公司簡介與財務報告邊界",
+    guidance:
+      "填寫公司基礎營運資訊,並說明與財務報表申報主體(Reporting Entity)的一致性。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch1-2",
+    chapterId: "ch1",
+    code: "1.2",
+    title: "報告目的與主要使用者",
+    guidance:
+      "明確定義報告旨在提供給股東、投資人與債權人等財務市場參與者,作為評估企業核心價值的依據。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch1-3",
+    chapterId: "ch1",
+    code: "1.3",
+    title: "氣候與永續政策聲明",
+    guidance:
+      "由最高管理階層(如董事長、執行長)簽署的永續承諾、淨零碳排路徑方針。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch1-4",
+    chapterId: "ch1",
+    code: "1.4",
+    title: "氣候治理架構與職責",
+    guidance:
+      "IFRS S2 核心:詳細揭露董事會對氣候風險的監督機制(如何聽取報告、頻率、納入決策),以及管理階層(如永續長、推行委員會)如何執行溫室氣體日常控管。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch1-5",
+    chapterId: "ch1",
+    code: "1.5",
+    title: "組織邊界設定方法",
+    guidance:
+      "依據 IFRS S2 規定,說明組織邊界如何與財務合併報表對齊(採用控制權法或股權比例法),並明確交代若有投資聯屬公司或合資企業時的範疇界定。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch1-6",
+    chapterId: "ch1",
+    code: "1.6",
+    title: "報告涵蓋期間與重大財務連結",
+    guidance:
+      "明訂報告時間必須與財務報表期間一致(通常為會計年度)。揭露資訊的發布必須與財務報告同步。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch2-intro",
+    chapterId: "ch2",
+    code: "第二章",
+    title: "報告邊界(導論)",
+    guidance:
+      "說明如何將氣候風險與商業策略結合,據以界定價值鏈中應納入盤查的重大碳排放項目。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch2-1",
+    chapterId: "ch2",
+    code: "2.1",
+    title: "基準年與歷史碳數據追蹤",
+    guidance:
+      "設定碳減量策略的比較基準年,並訂定嚴格的「基準年重新計算政策」(當公司發生實體併購、分拆或計算方法重大改變時,觸發基準年數據重算之門檻)。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch2-2",
+    chapterId: "ch2",
+    code: "2.2",
+    title: "溫室氣體排放源鑑別",
+    guidance:
+      "跨越全價值鏈(包含上游供應鏈、營運本體、下游產品生命週期)進行系統化排放源鑑別。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch2-3",
+    chapterId: "ch2",
+    code: "2.3",
+    title: "排放範疇與類別劃分",
+    guidance:
+      "IFRS S2 指標要求:依據 GHG Protocol 嚴格區分為範疇一(直接排放)、範疇二(能源間接排放)與範疇三(價值鏈間接排放,包含 15 項子類別)。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch3-intro",
+    chapterId: "ch3",
+    code: "3.1",
+    title: "溫室氣體排放量計算說明(含導論)",
+    guidance:
+      "聲明本章數據為企業氣候風險量化之基礎,用以評估碳定價或法規轉型帶來的潛在財務衝擊。列出完整排放源矩陣圖,盤點並確認所有活動均涵蓋京都議定書之七大溫室氣體(CO2, CH4, N2O, HFCs, PFCs, SF6, NF3)。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch3-2",
+    chapterId: "ch3",
+    code: "3.2",
+    title: "活動數據與排放係數選擇層級",
+    guidance:
+      "建立數據品質階層方針。說明原始數據(Primary Data,如電費單、採購發票)與推估數據的比例,並列出所引用的官方或國際權威排放係數庫。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch3-3",
+    chapterId: "ch3",
+    code: "3.3",
+    title: "量化方法學與 GWP 基礎",
+    guidance:
+      "說明核心計算算式,並載明遵循 IFRS S2 規定,統一採用 IPCC 最新公告之全球暖化潛勢值(GWP,如 AR6)進行 CO2e 的當量轉換。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch3-4",
+    chapterId: "ch3",
+    code: "3.4",
+    title: "各類排放量計算細節與推理",
+    guidance:
+      "完整公開各範疇(包含範疇二的所在地/市場基準、範疇三的供應鏈運輸、售出產品使用階段等)的算式邏輯、生質碳單獨報告說明及重大假設。",
+    isDataDriven: true,
+  },
+  {
+    id: "ch3-5",
+    chapterId: "ch3",
+    code: "3.5",
+    title: "量化方法與變更說明",
+    guidance:
+      "維持 IFRS S1 的可比性原則,詳細說明本年度是否有任何計算方法、係數或估算技術的變更與背後原因。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch3-6",
+    chapterId: "ch3",
+    code: "3.6",
+    title: "溫室氣體排放總量匯總表",
+    guidance:
+      "以結構化表格呈現絕對排放量(Absolute Emissions)與碳排放強度(Emissions Intensity,如每單位營收碳排、每噸產品碳排),並明確區分範疇一、二、三之數據。",
+    isDataDriven: true,
+  },
+  {
+    id: "ch4-intro",
+    chapterId: "ch4",
+    code: "第四章",
+    title: "數據品質管理(導論)",
+    guidance: "說明如何將碳數據的內部控制納入公司整體的風險管理系統中。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch4-1",
+    chapterId: "ch4",
+    code: "4.1",
+    title: "溫室氣體內部控制與數據品質管理",
+    guidance:
+      "描述碳盤查資訊系統(如 ERP 或碳盤查系統)的控管流程、防呆與覆核機制,以及所有核心量測儀器(如內部電表、流量計)的校正維護紀錄。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch4-2",
+    chapterId: "ch4",
+    code: "4.2",
+    title: "估算不確定性與情境風險分析",
+    guidance:
+      "定量評估:針對範疇一與範疇二數據,計算統計學上的不確定性(提供 95% 信賴區間上限與下限),評估量測誤差。定性評估:針對範疇三等高度依賴估算或外部第三方提供之數據,進行品質等級定性評分,並揭露估算方法的假設前提與重大不確定性來源。",
+    isDataDriven: true,
+  },
+  {
+    id: "ch5",
+    chapterId: "ch5",
+    code: "第五章",
+    title: "溫室氣體減量措施及內部績效追蹤",
+    guidance:
+      "轉型計畫(Transition Plan):說明公司如何透過營運優化或低碳投資來實現減碳,並說明所需的財務資源預算規劃。減量目標(Targets):揭露企業設定的氣候目標(如 2030 減碳 50%、2050 淨零),寫明是絕對目標或強度目標、是否通過科學基礎減量目標(SBTi)驗證、以及碳權(Carbon Offsets)預計使用的比例。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch6",
+    chapterId: "ch6",
+    code: "第六章",
+    title: "溫室氣體資訊管理及盤查作業",
+    guidance:
+      "說明企業如何鑑別實體風險(如極端氣候導致斷電、淹水)與轉型風險(如碳稅、低碳市場轉型),並說明如何將範疇三的價值鏈盤查結果作為減碳決策的依據。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch7",
+    chapterId: "ch7",
+    code: "第七章",
+    title: "溫室氣體內部查證及定期審查",
+    guidance:
+      "詳細揭露企業如何運用氣候情境分析(Climate Scenario Analysis)(例如在 1.5°C 或 2°C 以上的情境下)來測試企業商業模式與策略的彈性,並由管理階層定期審查因應。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch8",
+    chapterId: "ch8",
+    code: "第八章",
+    title: "溫室氣體盤查資訊管理及記錄保存",
+    guidance:
+      "說明碳管理如何與財務會計檔案、內部控制流程實質整合,並規範相關憑證(如水電費單據、生產報表、合約)的數位化與法定保存年限。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch9-intro",
+    chapterId: "ch9",
+    code: "第九章",
+    title: "查證(導論)",
+    guidance:
+      "說明為滿足財務市場與法規對於永續資訊「可信度」的要求,所安排的第三方獨立確信作業。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch9-1",
+    chapterId: "ch9",
+    code: "9.1",
+    title: "確信/查證範圍",
+    guidance:
+      "界定外部查證機構查驗的邊界,是否與本報告書及財務合併報表邊界完全重疊。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch9-2",
+    chapterId: "ch9",
+    code: "9.2",
+    title: "確信/查證遵循準則",
+    guidance:
+      "寫明第三方機構執行稽核時所遵循的國際通用的確信準則(如 ISAE 3410 溫室氣體聲明之確信業務、ISO 14064-3)。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch9-3",
+    chapterId: "ch9",
+    code: "9.3",
+    title: "實質性門檻",
+    guidance:
+      "界定外部查證容許的量化誤差門檻(如 5%),並揭露對財務投資人決策具有重大影響的「定性重大性」標準。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch9-4",
+    chapterId: "ch9",
+    code: "9.4",
+    title: "確信/查證保證等級",
+    guidance:
+      "明確載明確信級別。通常依照國際潮流或法規要求,範疇一、二採「合理確信(Reasonable Assurance)」,範疇三採「有限確信(Limited Assurance)」。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch10-intro",
+    chapterId: "ch10",
+    code: "第十章",
+    title: "報告之責任、目的與格式(導論)",
+    guidance: "確立報告的法律揭露責任與跨平台發布形式。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch10-1",
+    chapterId: "ch10",
+    code: "10.1",
+    title: "財務報導之呈現格式",
+    guidance:
+      "說明本碳盤查報告如何與年報、永續報告或財務報告書進行跨內容的相互索引,確保資訊透明且便於投資人查閱。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch10-2",
+    chapterId: "ch10",
+    code: "10.2",
+    title: "資訊公開與傳播途徑",
+    guidance:
+      "明列報告在公開資訊觀測站、公司官網、或是提交至國際評比平台(如 CDP)的取得管道與利害關係人諮詢窗口。",
+    isDataDriven: false,
+  },
+  {
+    id: "ch11",
+    chapterId: "ch11",
+    code: "第十一章",
+    title: "參考文獻",
+    guidance:
+      "詳細條列編寫此報告所應用的所有外部方法學(如 IFRS S2 準則文本、GHG Protocol 企業標準)、各國政府或國際能源署(IEA)公告的最新電力排碳係數與產業統計技術參數庫。",
+    isDataDriven: false,
+  },
+];
+
+export const CARBON_REPORT_SECTION_COUNT = CARBON_REPORT_OUTLINE.length;
+
+// Info: (20260713 - Tzuhan) 產生段落在 Markdown 中的切分標題;與 use_carbon_chat 的 `### SECTION` 切分規則耦合,勿任意變更前綴
+export const buildSectionHeadingByTitle = (
+  title: string,
+  index: number,
+): string => `### SECTION ${String(index + 1).padStart(2, "0")}: ${title}`;
+
+export const buildSectionHeading = (
+  section: ICarbonReportSection,
+  index: number,
+): string =>
+  buildSectionHeadingByTitle(`${section.code} ${section.title}`, index);

--- a/src/constants/carbon_report_outline.ts
+++ b/src/constants/carbon_report_outline.ts
@@ -15,6 +15,7 @@ export interface ICarbonReportSection {
   isDataDriven: boolean;
 }
 
+// ToDo: (20260713 - Luphia) 章節 title 為硬編中文，將顯示於大綱導覽 UI；如需多語系報告請抽為 i18n key（guidance 屬注入 AI 的 prompt data，可留）
 export const CARBON_REPORT_CHAPTERS: ICarbonReportChapter[] = [
   { id: "ch1", title: "第一章 組織與治理概況" },
   { id: "ch2", title: "第二章 報告邊界" },
@@ -29,6 +30,7 @@ export const CARBON_REPORT_CHAPTERS: ICarbonReportChapter[] = [
   { id: "ch11", title: "第十一章 參考文獻" },
 ];
 
+// ToDo: (20260713 - Luphia) 各段落 title 為硬編中文，將顯示於大綱導覽 UI；如需多語系報告請抽為 i18n key（同 CARBON_REPORT_CHAPTERS）
 export const CARBON_REPORT_OUTLINE: ICarbonReportSection[] = [
   {
     id: "ch1-intro",

--- a/src/hooks/use_carbon_chat.ts
+++ b/src/hooks/use_carbon_chat.ts
@@ -5,8 +5,13 @@ import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import {
   IChatSession,
   IChatMessage,
+  IReportProgressStats,
   ChatRoleEnum,
 } from "@/types/carbon_chatbot.types";
+import {
+  CARBON_REPORT_OUTLINE,
+  CARBON_REPORT_SECTION_COUNT,
+} from "@/constants/carbon_report_outline";
 import { INITIAL_SESSIONS } from "@/constants/carbon_chatbot.mock";
 import { useTranslation } from "@/i18n/i18n_context";
 import { subscribeChatroom } from "@/lib/chatroom";
@@ -24,8 +29,6 @@ import { request } from "@/lib/utils/request";
 import { useAuth } from "@/contexts/auth_context";
 import {
   DEFAULT_SESSION_ID,
-  USER_PROGRESS_MAX,
-  USER_PROGRESS_STEP,
   SESSION_PROGRESS_MAX,
   CARBON_CHAT_CHANNEL_PREFIX,
   CARBON_CHAT_REPLY_TIMEOUT_MS,
@@ -45,6 +48,10 @@ export const useCarbonChat = () => {
   const [isError, setIsError] = useState<boolean>(false);
   // Info: (20260712 - Luphia) 是否已於進入時完成一次手勢解鎖（PRF）；未解鎖前不呼叫 AI、不顯示對話
   const [isUnlocked, setIsUnlocked] = useState<boolean>(false);
+  // Info: (20260713 - Tzuhan) 目前對話正在引導的報告段落(vibe 模式:跳段 = 切換對話目標)
+  const [activeParagraphId, setActiveParagraphId] = useState<string | null>(
+    null,
+  );
   // Info: (20260712 - Luphia) 歷史訊息分頁狀態（上卷載入更多）
   const [hasMoreHistory, setHasMoreHistory] = useState<boolean>(false);
   const [isLoadingHistory, setIsLoadingHistory] = useState<boolean>(false);
@@ -186,9 +193,56 @@ export const useCarbonChat = () => {
 
   const activeSession = sessionsData[activeSessionId];
   // Info: (20260712 - Luphia) 以 useMemo 快取 session 列表，避免每次 render 重建陣列
+  // Info: (20260713 - Tzuhan) 有段落大綱的 session,progress 一律以真實完成段落數推導(廢除訊息計次假進度)
   const sessionsList = useMemo(
-    () => Object.values(sessionsData),
+    () =>
+      Object.values(sessionsData).map((session) => {
+        const paragraphs = session.reportData?.paragraphs;
+        if (!paragraphs || paragraphs.length === 0) return session;
+        const completedCount = paragraphs.filter((p) => p.isCompleted).length;
+        return {
+          ...session,
+          progress: Math.round((completedCount / paragraphs.length) * 100),
+        };
+      }),
     [sessionsData],
+  );
+
+  // Info: (20260713 - Tzuhan) 完成/查核雙軌統計:工具列膠囊與進度浮窗共用的單一來源
+  const reportStats: IReportProgressStats = useMemo(() => {
+    const paragraphs = activeSession?.reportData?.paragraphs ?? [];
+    const totalCount = paragraphs.length || CARBON_REPORT_SECTION_COUNT;
+    const completedCount = paragraphs.filter((p) => p.isCompleted).length;
+    const verifiedCount = paragraphs.filter((p) => p.isVerified).length;
+    return {
+      completedCount,
+      verifiedCount,
+      totalCount,
+      completedPercent: Math.round((completedCount / totalCount) * 100),
+      verifiedPercent: Math.round((verifiedCount / totalCount) * 100),
+    };
+  }, [activeSession]);
+
+  // Info: (20260713 - Tzuhan) 跳段(vibe 模式):標記進行中段落、將該段撰寫指引寫入 currentStep 供 AI 引導、預填對話輸入
+  const jumpToParagraph = useCallback(
+    (paragraphId: string) => {
+      setActiveParagraphId(paragraphId);
+      const section = CARBON_REPORT_OUTLINE.find((s) => s.id === paragraphId);
+      if (!section) return;
+
+      setSessionsData((prev) => {
+        const updatedSession = { ...prev[activeSessionId] };
+        updatedSession.currentStep = `${section.code} ${section.title}：${section.guidance}`;
+        return { ...prev, [activeSessionId]: updatedSession };
+      });
+
+      setInputValue(
+        t("carbon_chatbot.jump_prompt", {
+          section: `${section.code} ${section.title}`,
+        }),
+      );
+    },
+    [activeSessionId, t],
   );
 
   // Info: (20260712 - Luphia) 進入時先預抓金鑰紀錄，避免解鎖手勢當下「fetch → PRF」耗掉 user activation
@@ -223,16 +277,19 @@ export const useCarbonChat = () => {
     prevSessionId.current = activeSessionId;
   }, [lastMessageId, activeSessionId, isTyping]);
 
-  // Info: (20260712 - Luphia) 合併原本重複的 toggleParagraphCompleted / toggleParagraphVerified，改由單一 helper 依欄位切換
-  const toggleParagraphField = useCallback(
-    (paragraphId: string, field: "isCompleted" | "isVerified") => {
+  // Info: (20260713 - Tzuhan) vibe 模式:isCompleted 由系統依生成狀態判定,不開放手動切換;僅保留 isVerified 人工簽核
+  const toggleParagraphVerified = useCallback(
+    (paragraphId: string) => {
       setSessionsData((prev) => {
         const updatedSession = { ...prev[activeSessionId] };
         if (!updatedSession.reportData?.paragraphs) return prev;
 
-        const newParagraphs = updatedSession.reportData.paragraphs.map((p) =>
-          p.id === paragraphId ? { ...p, [field]: !p[field] } : p,
-        );
+        const newParagraphs = updatedSession.reportData.paragraphs.map((p) => {
+          if (p.id !== paragraphId) return p;
+          // Info: (20260713 - Tzuhan) 未生成內容的段落不可簽核(零信任:先有產出才有查核)
+          if (!p.isCompleted) return p;
+          return { ...p, isVerified: !p.isVerified };
+        });
 
         updatedSession.reportData = {
           ...updatedSession.reportData,
@@ -244,62 +301,49 @@ export const useCarbonChat = () => {
     [activeSessionId],
   );
 
-  const toggleParagraphCompleted = useCallback(
-    (paragraphId: string) => toggleParagraphField(paragraphId, "isCompleted"),
-    [toggleParagraphField],
-  );
-
-  const toggleParagraphVerified = useCallback(
-    (paragraphId: string) => toggleParagraphField(paragraphId, "isVerified"),
-    [toggleParagraphField],
-  );
-
   const handleMarkdownChange = useCallback(
     (newMarkdown: string) => {
       setSessionsData((prev) => {
         const updatedSession = { ...prev[activeSessionId] };
         if (!updatedSession.reportData?.paragraphs) return prev;
 
-        // Info: (20260708 - Tzuhan) Regex/Diff 比對法：用標題切分段落並比對
+        // Info: (20260713 - Tzuhan) 以 ### SECTION 切分並僅保留段落區塊(排除文件標頭),
+        // Info: (20260713 - Tzuhan) 同時去除組稿時附加的 --- 分隔線,避免與段落原文比對時誤判為變更
         const blocks = newMarkdown
           .split(/(?=### SECTION)/)
-          .map((s) => s.trim())
-          .filter(Boolean);
-        let hasChanges = false;
-        const newParagraphs = [...updatedSession.reportData.paragraphs];
+          .map((s) => s.replace(/\n+---\s*$/, "").trim())
+          .filter((s) => s.startsWith("### SECTION"));
 
-        // Info: (20260709 - Tzuhan) 防呆機制：如果 Regex 切割出來的區塊數量與原先的段落數量不一致，
-        // Info: (20260709 - Tzuhan) 代表使用者可能誤刪了關鍵的切分標籤 (### SECTION)，為確保資料正確性，直接將所有段落設為未查核。
-        if (blocks.length !== newParagraphs.length) {
-          for (let i = 0; i < newParagraphs.length; i++) {
-            const nextContent = blocks[i] || newParagraphs[i].content;
+        // Info: (20260713 - Tzuhan) 預覽渲染全部段落(未生成者為佔位區塊),故區塊與 33 段依序 1:1 對齊
+        // Info: (20260709 - Tzuhan) 防呆機制:區塊數與段落數不一致,代表使用者可能誤刪切分標籤 (### SECTION),
+        // Info: (20260709 - Tzuhan) 為確保資料正確性,將所有已生成段落設為未查核
+        const isBlockCountMismatched =
+          blocks.length !== updatedSession.reportData.paragraphs.length;
+
+        let hasChanges = false;
+        const newParagraphs = updatedSession.reportData.paragraphs.map(
+          (p, index) => {
+            // Info: (20260713 - Tzuhan) 未生成段落為唯讀佔位,不接受編輯寫入(內容須由 AI 對話生成)
+            if (!p.content) return p;
+            const nextContent = isBlockCountMismatched
+              ? p.content
+              : (blocks[index] ?? p.content);
+
+            const isContentChanged = nextContent !== p.content;
+            const shouldResetVerified =
+              (isContentChanged || isBlockCountMismatched) && p.isVerified;
             // Info: (20260712 - Luphia) 僅在內容或查核狀態確實變動時才更新，避免無謂的狀態變更
-            if (
-              nextContent !== newParagraphs[i].content ||
-              newParagraphs[i].isVerified
-            ) {
-              newParagraphs[i] = {
-                ...newParagraphs[i],
-                content: nextContent,
-                isVerified: false,
-              };
-              hasChanges = true;
-            }
-          }
-        } else {
-          for (let i = 0; i < newParagraphs.length; i++) {
-            const currentBlock = blocks[i] || "";
-            // Info: (20260709 - Tzuhan) 如果內容被修改，重置查核狀態為未查核 (isVerified: false)
-            if (currentBlock !== newParagraphs[i].content) {
-              newParagraphs[i] = {
-                ...newParagraphs[i],
-                content: currentBlock,
-                isVerified: false,
-              };
-              hasChanges = true;
-            }
-          }
-        }
+            if (!isContentChanged && !shouldResetVerified) return p;
+
+            hasChanges = true;
+            return {
+              ...p,
+              content: nextContent,
+              // Info: (20260709 - Tzuhan) 內容被修改,重置查核狀態為未查核 (isVerified: false)
+              isVerified: false,
+            };
+          },
+        );
 
         if (!hasChanges) return prev;
 
@@ -385,13 +429,10 @@ export const useCarbonChat = () => {
       text: inputValue,
     };
 
+    // Info: (20260713 - Tzuhan) 廢除訊息計次假進度;進度一律由 reportStats 依實際完成段落數推導
     setSessionsData((prev) => {
       const updatedSession = { ...prev[activeSessionId] };
       updatedSession.messages = [...updatedSession.messages, userMessage];
-      updatedSession.progress = Math.min(
-        USER_PROGRESS_MAX,
-        updatedSession.progress + USER_PROGRESS_STEP,
-      );
       return { ...prev, [activeSessionId]: updatedSession };
     });
 
@@ -564,7 +605,9 @@ export const useCarbonChat = () => {
     isLoadingHistory,
     loadMoreHistory,
     handleSendMessage,
-    toggleParagraphCompleted,
+    reportStats,
+    activeParagraphId,
+    jumpToParagraph,
     toggleParagraphVerified,
     handleMarkdownChange,
     chatEndRef,

--- a/src/i18n/locales/en/carbon_chatbot.ts
+++ b/src/i18n/locales/en/carbon_chatbot.ts
@@ -40,4 +40,20 @@ export const carbonChatbot = {
   status_incomplete: "Incomplete",
   status_verified: "Verified",
   status_unverified: "Unverified",
+  outline_title: "Report Outline",
+  outline_button: "Outline",
+  completed_short: "Done",
+  verified_short: "Verified",
+  verified_progress: "Human Review Progress",
+  jump_aria_label: "Jump to this section",
+  close_outline: "Close outline",
+  data_driven_badge:
+    "Data section: figures are reconciled by the deterministic engine, not AI-generated",
+  jump_prompt: "Please help me complete the section 「{{section}}」.",
+  section_placeholder:
+    "This section has not been generated yet. Tell the Carbon Accountant in the chat that you want to work on it, and the content will appear here in real time.",
+  report_status_draft:
+    "Report status: Draft (content is generated section by section by AI and must pass human review before finalization)",
+  report_button: "Report",
+  close_report: "Close report",
 };

--- a/src/i18n/locales/ja/carbon_chatbot.ts
+++ b/src/i18n/locales/ja/carbon_chatbot.ts
@@ -40,4 +40,20 @@ export const carbonChatbot = {
   status_incomplete: "未完了",
   status_verified: "検証済み",
   status_unverified: "未検証",
+  outline_title: "章立て一覧",
+  outline_button: "目次",
+  completed_short: "完了",
+  verified_short: "検証",
+  verified_progress: "人的レビュー進捗",
+  jump_aria_label: "このセクションへ移動",
+  close_outline: "目次を閉じる",
+  data_driven_badge:
+    "データセクション:数値はシステムの決定論エンジンで算出され、AI 生成ではありません",
+  jump_prompt: "「{{section}}」セクションの作成を手伝ってください。",
+  section_placeholder:
+    "このセクションはまだ生成されていません。左側のチャットでカーボン会計士に作成したい旨を伝えると、内容がここにリアルタイムで表示されます。",
+  report_status_draft:
+    "レポートステータス:ドラフト(内容は AI がセクションごとに生成し、人的レビューを経て確定されます)",
+  report_button: "レポート",
+  close_report: "レポートを閉じる",
 };

--- a/src/i18n/locales/ko/carbon_chatbot.ts
+++ b/src/i18n/locales/ko/carbon_chatbot.ts
@@ -40,4 +40,20 @@ export const carbonChatbot = {
   status_incomplete: "미완료",
   status_verified: "검증됨",
   status_unverified: "미검증",
+  outline_title: "목차",
+  outline_button: "목차",
+  completed_short: "완료",
+  verified_short: "검증",
+  verified_progress: "수동 검토 진행률",
+  jump_aria_label: "이 섹션으로 이동",
+  close_outline: "목차 닫기",
+  data_driven_badge:
+    "데이터 섹션: 수치는 시스템 결정론 엔진에서 계산되며 AI 생성이 아닙니다",
+  jump_prompt: "「{{section}}」 섹션 작성을 도와주세요.",
+  section_placeholder:
+    "이 섹션은 아직 생성되지 않았습니다. 왼쪽 대화에서 탄소 회계사에게 작성 의사를 알리면 내용이 실시간으로 여기에 표시됩니다.",
+  report_status_draft:
+    "보고서 상태: 초안 (내용은 AI가 섹션별로 생성하며 수동 검토 후 확정됩니다)",
+  report_button: "보고서",
+  close_report: "보고서 닫기",
 };

--- a/src/i18n/locales/zh_cn/carbon_chatbot.ts
+++ b/src/i18n/locales/zh_cn/carbon_chatbot.ts
@@ -39,4 +39,18 @@ export const carbonChatbot = {
   status_incomplete: "未完成",
   status_verified: "已查核",
   status_unverified: "未查核",
+  outline_title: "章节目录",
+  outline_button: "目录",
+  completed_short: "完成",
+  verified_short: "查核",
+  verified_progress: "人工查核进度",
+  jump_aria_label: "跳至此段落",
+  close_outline: "关闭章节目录",
+  data_driven_badge: "数据段落:数字由系统勾稽计算,非 AI 产出",
+  jump_prompt: "请协助我完成「{{section}}」这个段落。",
+  section_placeholder:
+    "本段尚未生成。回到左侧对话告诉碳会计师你想撰写这一段,内容将实时出现在这里。",
+  report_status_draft: "报告状态:草稿(内容由 AI 逐段生成,经人工查核后方可定稿)",
+  report_button: "报告",
+  close_report: "关闭报告",
 };

--- a/src/i18n/locales/zh_tw/carbon_chatbot.ts
+++ b/src/i18n/locales/zh_tw/carbon_chatbot.ts
@@ -39,4 +39,18 @@ export const carbonChatbot = {
   status_incomplete: "未完成",
   status_verified: "已查核",
   status_unverified: "未查核",
+  outline_title: "章節目錄",
+  outline_button: "目錄",
+  completed_short: "完成",
+  verified_short: "查核",
+  verified_progress: "人工查核進度",
+  jump_aria_label: "跳至此段落",
+  close_outline: "關閉章節目錄",
+  data_driven_badge: "數據段落:數字由系統勾稽計算,非 AI 產出",
+  jump_prompt: "請協助我完成「{{section}}」這個段落。",
+  section_placeholder:
+    "本段尚未生成。回到左側對話告訴碳會計師你想撰寫這一段,內容將即時出現在這裡。",
+  report_status_draft: "報告狀態:草稿(內容由 AI 逐段生成,經人工查核後方可定稿)",
+  report_button: "報告",
+  close_report: "關閉報告",
 };

--- a/src/types/carbon_chatbot.types.ts
+++ b/src/types/carbon_chatbot.types.ts
@@ -37,10 +37,23 @@ export interface IReportCategory {
 
 export interface IReportParagraph {
   id: string;
+  // Info: (20260713 - Tzuhan) 對應 CARBON_REPORT_OUTLINE 的章節分組與數據段落標記
+  chapterId: string;
+  code: string;
   title: string;
   content: string;
   isCompleted: boolean;
   isVerified: boolean;
+  isDataDriven: boolean;
+}
+
+// Info: (20260713 - Tzuhan) 報告段落統計(完成/查核雙軌進度的單一來源)
+export interface IReportProgressStats {
+  completedCount: number;
+  verifiedCount: number;
+  totalCount: number;
+  completedPercent: number;
+  verifiedPercent: number;
 }
 
 export interface IReportData {


### PR DESCRIPTION
### DEVELOP
- [X] Description: Implemented the carbon report outline navigation for the carbon chatbot. Added the IFRS S1/S2-aligned standard outline (11 chapters / 33 sections) as a single-source constant with per-section AI guidance, and built outline navigation UI (toolbar, rail, drawer, tree, mobile modal) around it. Conversation now supports vibe-mode section jumping: selecting a section switches the AI's writing target and prefills the chat input. Replaced the message-count fake progress with completed/verified dual-track stats derived from actual paragraph state; `isCompleted` is now system-derived and only `isVerified` remains manually togglable (and only after content exists). The PDF preview renders all 33 sections with placeholders for ungenerated ones and auto-scrolls to the active section. Added mobile (<xl) layout with outline modal and fullscreen report overlay, plus a `compact` MarkdownContent variant and `defaultViewMode`/`contentVariant` props on PdfEditor for embedded use. i18n keys added for en/ja/ko/zh_cn/zh_tw.

#### Related Issues
- [X] Issue Number: [#6483](https://github.com/CAFECA-IO/iSunFA/issues/6483)

#### Checklist
- [x] Used `@` in import paths.
- [x] Verified naming convention compliance ([[Naming Convention Guidelines](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md)](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md)).
- [x] Coding style verification: checked
- [x] new Library: 0
- [x] new Class / Component: 5 (ReportToolbar, OutlineRail, OutlineDrawer, OutlineTree, OutlineModal)
- [x] new loop: 4 (array map/filter for progress stats derivation and outline rendering; all bounded by the fixed 33-section outline)
- [x] new recursive: 0
- [x] high risk: 0
- [x] new sql: 0

#### UML Diagrams
- None

#### Additional Notes
- Progress is now derived solely from real paragraph state (`reportStats` single source); the message-count based `USER_PROGRESS_STEP` fake progress was removed.
- Guarded against invalid states: ungenerated sections are read-only placeholders in the editor, cannot be verified, and editing a section resets its verified status.
- Markdown section splitting (`### SECTION`) now strips assembly-time `---` separators to avoid false-positive change detection; block-count mismatch still resets verification as a fail-safe.
- Verified responsive behavior at the xl (1280px) breakpoint: outline modal + fullscreen report overlay on mobile, rail + drawer on desktop.
- ESLint and Prettier pass on all changed files; jest could not run in the local sandbox (missing ARM64 SWC binary) — relying on CI.