### PR TITLE
Feature/carbon report data binding

### DIFF
--- a/src/__tests__/carbon_articulation.test.ts
+++ b/src/__tests__/carbon_articulation.test.ts
@@ -1,0 +1,176 @@
+// Info: (20260720 - Emily) #6520 質量守恆勾稽測試:等式邊界、損耗容差、單位換算、非庫存跳過、合理性區間
+// Info: (20260720 - Emily) 純決定性服務(無 DB/LLM),直接實例化,無需 mock
+
+import { describe, it, expect } from "@jest/globals";
+import { CarbonArticulationService } from "@/services/carbon_articulation.service";
+import {
+  ArticulationStatusEnum,
+  ArticulationViolationReasonEnum,
+  ArticulationWarningReasonEnum,
+} from "@/constants/carbon_articulation";
+import { GhgProtocolCategory } from "@/constants/esg";
+import { MeasurementUnit } from "@/constants/enums";
+import {
+  IActivityRecord,
+  IMaterialStockRecord,
+} from "@/types/carbon_chatbot.types";
+
+const service = new CarbonArticulationService();
+
+const dieselActivity = (quantity: string, unit = MeasurementUnit.LITER): IActivityRecord => ({
+  scopeCategory: GhgProtocolCategory.SCOPE_1_DIRECT,
+  sourceName: "柴油",
+  quantity,
+  unit,
+});
+
+const dieselStock = (
+  opening: string,
+  purchased: string,
+  closing: string,
+): IMaterialStockRecord => ({
+  materialName: "柴油",
+  openingQuantity: opening,
+  purchasedQuantity: purchased,
+  closingQuantity: closing,
+  unit: MeasurementUnit.LITER,
+});
+
+describe("CarbonArticulationService mass conservation", () => {
+  it("should freeze when consumption exceeds opening + purchased (Emily's acceptance case)", () => {
+    // Info: (20260720 - Emily) 期初 100L + 採購 50L,帳上消耗 200L → 缺口 50L 遠超 5% 容差
+    const result = service.check(
+      [dieselActivity("200")],
+      [dieselStock("100", "50", "0")],
+    );
+    expect(result.status).toBe(ArticulationStatusEnum.VIOLATED);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]).toMatchObject({
+      materialName: "柴油",
+      reason: ArticulationViolationReasonEnum.MASS_GAP_EXCEEDS_TOLERANCE,
+      expectedConsumption: "150",
+      actualConsumption: "200",
+      gap: "50",
+    });
+  });
+
+  it("should pass when the gap is within the loss ratio tolerance", () => {
+    // Info: (20260720 - Emily) 預期消耗 1000L,帳上 960L → 缺口 40L = 4% < 5% 容差(合理損耗)
+    const result = service.check(
+      [dieselActivity("960")],
+      [dieselStock("400", "700", "100")],
+    );
+    expect(result.status).toBe(ArticulationStatusEnum.PASSED);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it("should violate exactly beyond the tolerance boundary and pass exactly on it", () => {
+    // Info: (20260720 - Emily) 預期 1000L,容差 50L:帳上 950L(缺口=50,邊界上)過;949L(缺口=51)不過
+    const onBoundary = service.check(
+      [dieselActivity("950")],
+      [dieselStock("1000", "0", "0")],
+    );
+    expect(onBoundary.status).toBe(ArticulationStatusEnum.PASSED);
+
+    const beyond = service.check(
+      [dieselActivity("949")],
+      [dieselStock("1000", "0", "0")],
+    );
+    expect(beyond.status).toBe(ArticulationStatusEnum.VIOLATED);
+    expect(beyond.violations[0].gap).toBe("51");
+  });
+
+  it("should reject physically impossible closing stock (stock created from nothing)", () => {
+    const result = service.check([], [dieselStock("100", "50", "200")]);
+    expect(result.status).toBe(ArticulationStatusEnum.VIOLATED);
+    expect(result.violations[0].reason).toBe(
+      ArticulationViolationReasonEnum.NEGATIVE_EXPECTED_CONSUMPTION,
+    );
+  });
+
+  it("should align units deterministically (stock in tonnes, consumption in kg)", () => {
+    // Info: (20260720 - Emily) 期初 2t + 採購 0 - 期末 1t = 預期 1t;帳上 1000kg = 1t → 精確守恆
+    const stock: IMaterialStockRecord = {
+      materialName: "重油",
+      openingQuantity: "2",
+      purchasedQuantity: "0",
+      closingQuantity: "1",
+      unit: MeasurementUnit.TONNE,
+    };
+    const activity: IActivityRecord = {
+      scopeCategory: GhgProtocolCategory.SCOPE_1_DIRECT,
+      sourceName: "重油",
+      quantity: "1,000",
+      unit: MeasurementUnit.KG,
+    };
+    const result = service.check([activity], [stock]);
+    expect(result.status).toBe(ArticulationStatusEnum.PASSED);
+  });
+
+  it("should flag cross-dimension units as unverifiable (UNIT_MISMATCH)", () => {
+    const result = service.check(
+      [dieselActivity("100", MeasurementUnit.KWH)],
+      [dieselStock("100", "0", "0")],
+    );
+    expect(result.status).toBe(ArticulationStatusEnum.VIOLATED);
+    expect(result.violations[0].reason).toBe(
+      ArticulationViolationReasonEnum.UNIT_MISMATCH,
+    );
+  });
+
+  it("should be NOT_APPLICABLE without stock records (electricity-only inventory)", () => {
+    const electricity: IActivityRecord = {
+      scopeCategory: GhgProtocolCategory.SCOPE_2_INDIRECT,
+      sourceName: "外購電力",
+      quantity: "1,200,000",
+      unit: MeasurementUnit.KWH,
+    };
+    const result = service.check([electricity], []);
+    expect(result.status).toBe(ArticulationStatusEnum.NOT_APPLICABLE);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it("should require zero consumption when expected consumption is zero", () => {
+    const result = service.check(
+      [dieselActivity("10")],
+      [dieselStock("100", "0", "100")],
+    );
+    expect(result.status).toBe(ArticulationStatusEnum.VIOLATED);
+  });
+});
+
+describe("CarbonArticulationService plausibility (non-stockable)", () => {
+  it("should warn but not freeze on implausible electricity usage (999 億度)", () => {
+    const electricity: IActivityRecord = {
+      scopeCategory: GhgProtocolCategory.SCOPE_2_INDIRECT,
+      sourceName: "外購電力",
+      quantity: "99,900,000,000",
+      unit: MeasurementUnit.KWH,
+    };
+    const result = service.check([electricity], []);
+    // Info: (20260720 - Emily) 超界僅警示:資料仍是事實(可能為集團級數據),不凍結
+    expect(result.status).toBe(ArticulationStatusEnum.NOT_APPLICABLE);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatchObject({
+      sourceName: "外購電力",
+      reason: ArticulationWarningReasonEnum.QUANTITY_EXCEEDS_PLAUSIBLE_MAX,
+    });
+  });
+
+  it("should not warn for plausible quantities and skip stockable units", () => {
+    const result = service.check(
+      [
+        {
+          scopeCategory: GhgProtocolCategory.SCOPE_2_INDIRECT,
+          sourceName: "外購電力",
+          quantity: "1,200,000",
+          unit: MeasurementUnit.KWH,
+        },
+        // Info: (20260720 - Emily) 庫存類單位不跑合理性(由守恆檢核把關)
+        dieselActivity("999999999999"),
+      ],
+      [],
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/__tests__/carbon_inventory.test.ts
+++ b/src/__tests__/carbon_inventory.test.ts
@@ -9,6 +9,10 @@ import {
   CARBON_INVENTORY_MIN_ACTIVITY_RECORDS,
 } from "@/lib/carbon_inventory";
 import { CarbonInventoryStep } from "@/constants/carbon_chatbot";
+import {
+  ArticulationStatusEnum,
+  ArticulationViolationReasonEnum,
+} from "@/constants/carbon_articulation";
 import { GhgProtocolCategory } from "@/constants/esg";
 import { MeasurementUnit } from "@/constants/enums";
 import {
@@ -92,9 +96,105 @@ describe("computeInventoryStep (deterministic state machine)", () => {
     );
     expect(computeInventoryStep(s)).toBe(CarbonInventoryStep.EMISSION_FACTORS);
 
-    // Info: (20260716 - Emily) 全部有係數 → REVIEW(REVIEW 出口由 #6520 質量守恆裁決，現階段不可能 COMPLETED)
+    // Info: (20260716 - Emily) 全部有係數 → REVIEW
     s.activities = s.activities.map((a) => ({ ...a, emissionFactor: "0.495" }));
     expect(computeInventoryStep(s)).toBe(CarbonInventoryStep.REVIEW);
+
+    // Info: (20260720 - Emily) #6520 REVIEW 出口:計算總表無待補 + 守恆勾稽非違反 → COMPLETED
+    const passedLedger = {
+      entries: [],
+      pending: [],
+      scopeSubtotals: {},
+      totalCo2eKg: "0",
+      computedAt: new Date().toISOString(),
+    };
+    s.computedLedger = {
+      ...passedLedger,
+      articulation: {
+        status: ArticulationStatusEnum.VIOLATED,
+        violations: [
+          {
+            materialName: "柴油",
+            unit: MeasurementUnit.LITER,
+            reason:
+              ArticulationViolationReasonEnum.MASS_GAP_EXCEEDS_TOLERANCE,
+            expectedConsumption: "150",
+            actualConsumption: "200",
+            gap: "50",
+          },
+        ],
+        warnings: [],
+        checkedAt: new Date().toISOString(),
+      },
+    };
+    expect(computeInventoryStep(s)).toBe(CarbonInventoryStep.REVIEW);
+
+    s.computedLedger = {
+      ...passedLedger,
+      articulation: {
+        status: ArticulationStatusEnum.PASSED,
+        violations: [],
+        warnings: [],
+        checkedAt: new Date().toISOString(),
+      },
+    };
+    expect(computeInventoryStep(s)).toBe(CarbonInventoryStep.COMPLETED);
+  });
+
+  it("should merge stock records with dedupe and surface violation facts to the persona", () => {
+    const s0 = createEmptyInventoryState();
+    const stock = {
+      materialName: "柴油",
+      openingQuantity: "100",
+      purchasedQuantity: "50",
+      closingQuantity: "0",
+      unit: MeasurementUnit.LITER,
+    };
+    const m1 = mergeInventoryExtraction(s0, {
+      activities: [],
+      stockRecords: [stock],
+    });
+    expect(m1.addedCount).toBe(1);
+    expect(m1.state.stockRecords).toHaveLength(1);
+
+    // Info: (20260720 - Emily) 同物料+單位 = 同一筆,後到的萃取不覆蓋
+    const m2 = mergeInventoryExtraction(m1.state, {
+      activities: [],
+      stockRecords: [{ ...stock, openingQuantity: "999" }],
+    });
+    expect(m2.addedCount).toBe(0);
+    expect(m2.state.stockRecords?.[0].openingQuantity).toBe("100");
+
+    // Info: (20260720 - Emily) 守恆違反 → persona 描述附等式事實(TS 產生,LLM 只措辭)
+    const violated = {
+      ...m2.state,
+      computedLedger: {
+        entries: [],
+        pending: [],
+        scopeSubtotals: {},
+        totalCo2eKg: "0",
+        computedAt: new Date().toISOString(),
+        articulation: {
+          status: ArticulationStatusEnum.VIOLATED,
+          violations: [
+            {
+              materialName: "柴油",
+              unit: MeasurementUnit.LITER,
+              reason:
+                ArticulationViolationReasonEnum.MASS_GAP_EXCEEDS_TOLERANCE,
+              expectedConsumption: "150",
+              actualConsumption: "200",
+              gap: "50",
+            },
+          ],
+          warnings: [],
+          checkedAt: new Date().toISOString(),
+        },
+      },
+    };
+    const description = describeInventoryStep(violated);
+    expect(description).toContain("質量守恆勾稽違反");
+    expect(description).toContain("缺口=50");
   });
 
   it("should describe missing prerequisites for the persona", () => {

--- a/src/__tests__/carbon_report_chart.test.ts
+++ b/src/__tests__/carbon_report_chart.test.ts
@@ -1,0 +1,157 @@
+// Info: (20260720 - Emily) #51 圖表模板測試:決定性輸出、數值保真、插入/替換不疊加、凍結與佔位、重算重建
+
+import { describe, it, expect } from "@jest/globals";
+import {
+  buildCarbonChartBlock,
+  insertCarbonChartBlock,
+  hasCarbonChartBlocks,
+  refreshCarbonChartBlocks,
+} from "@/lib/carbon_report_chart.builder";
+import {
+  CarbonChartTemplateEnum,
+  buildChartAnchorStart,
+} from "@/constants/carbon_report_charts";
+import { ArticulationStatusEnum } from "@/constants/carbon_articulation";
+import { GhgProtocolCategory } from "@/constants/esg";
+import { IComputedLedger } from "@/types/carbon_chatbot.types";
+
+const buildLedger = (
+  overrides?: Partial<IComputedLedger>,
+): IComputedLedger => ({
+  entries: [
+    {
+      activityKey: "k1",
+      scopeCategory: GhgProtocolCategory.SCOPE_2_INDIRECT,
+      sourceName: "外購電力",
+      quantityRaw: "2,500,000",
+      convertedQuantity: "2500000",
+      convertedUnit: "KWH",
+      co2eKg: "1235000",
+      factor: {
+        factorId: "f1",
+        name: "台電電力係數",
+        value: "0.494",
+        unit: "度(kwh)",
+        source: "台灣電力公司 2024",
+      },
+    },
+  ],
+  pending: [],
+  scopeSubtotals: {
+    [GhgProtocolCategory.SCOPE_1_DIRECT]: "5000",
+    [GhgProtocolCategory.SCOPE_2_INDIRECT]: "1235000",
+  },
+  totalCo2eKg: "1240000",
+  computedAt: "2026-07-20T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("buildCarbonChartBlock", () => {
+  it("should render a mermaid pie with engine figures verbatim (deterministic)", () => {
+    const block = buildCarbonChartBlock(
+      CarbonChartTemplateEnum.SCOPE_PIE,
+      buildLedger(),
+    );
+    expect(block).toContain("```mermaid");
+    expect(block).toContain("pie title");
+    // Info: (20260720 - Emily) mermaid 數值不加千分位(圖表引擎解析),與引擎值精確一致
+    expect(block).toContain('"SCOPE_2_INDIRECT" : 1235000');
+    expect(block).toContain('"SCOPE_1_DIRECT" : 5000');
+    expect(
+      buildCarbonChartBlock(CarbonChartTemplateEnum.SCOPE_PIE, buildLedger()),
+    ).toBe(block);
+  });
+
+  it("should render an xychart bar with scope axis and values", () => {
+    const block = buildCarbonChartBlock(
+      CarbonChartTemplateEnum.SCOPE_BAR,
+      buildLedger(),
+    );
+    expect(block).toContain("xychart-beta");
+    expect(block).toContain('"SCOPE_1_DIRECT", "SCOPE_2_INDIRECT"');
+    expect(block).toContain("bar [5000, 1235000]");
+  });
+
+  it("should reuse the #23 table for SOURCE_TABLE without double anchors", () => {
+    const block = buildCarbonChartBlock(
+      CarbonChartTemplateEnum.SOURCE_TABLE,
+      buildLedger(),
+    );
+    expect(block).toContain("| 外購電力 |");
+    expect(block).not.toContain("carbon-data-table");
+    expect(block).toContain(
+      buildChartAnchorStart(CarbonChartTemplateEnum.SOURCE_TABLE),
+    );
+  });
+
+  it("should render placeholder on empty ledger and freeze warning on violation", () => {
+    const empty = buildCarbonChartBlock(
+      CarbonChartTemplateEnum.SCOPE_PIE,
+      undefined,
+    );
+    expect(empty).toContain("資料不足");
+    expect(empty).not.toContain("```mermaid");
+
+    const frozen = buildCarbonChartBlock(
+      CarbonChartTemplateEnum.SCOPE_PIE,
+      buildLedger({
+        articulation: {
+          status: ArticulationStatusEnum.VIOLATED,
+          violations: [],
+          warnings: [],
+          checkedAt: "2026-07-20T00:00:00.000Z",
+        },
+      }),
+    );
+    expect(frozen).toContain("凍結");
+    expect(frozen).not.toContain("```mermaid");
+  });
+});
+
+describe("insertCarbonChartBlock / refreshCarbonChartBlocks", () => {
+  it("should append once and replace in place on re-insert (no stacking)", () => {
+    const narrative = "本段敘述。";
+    const pie = buildCarbonChartBlock(
+      CarbonChartTemplateEnum.SCOPE_PIE,
+      buildLedger(),
+    );
+    const v1 = insertCarbonChartBlock(
+      narrative,
+      CarbonChartTemplateEnum.SCOPE_PIE,
+      pie,
+    );
+    expect(hasCarbonChartBlocks(v1)).toBe(true);
+
+    const v2 = insertCarbonChartBlock(
+      v1,
+      CarbonChartTemplateEnum.SCOPE_PIE,
+      pie,
+    );
+    expect(
+      v2.split(buildChartAnchorStart(CarbonChartTemplateEnum.SCOPE_PIE)),
+    ).toHaveLength(2);
+    expect(v2.startsWith("本段敘述。")).toBe(true);
+  });
+
+  it("should rebuild all embedded charts from a new ledger (narrative untouched)", () => {
+    const pie = buildCarbonChartBlock(
+      CarbonChartTemplateEnum.SCOPE_PIE,
+      buildLedger(),
+    );
+    const content = insertCarbonChartBlock(
+      "敘述。",
+      CarbonChartTemplateEnum.SCOPE_PIE,
+      pie,
+    );
+
+    const refreshed = refreshCarbonChartBlocks(
+      content,
+      buildLedger({
+        scopeSubtotals: { [GhgProtocolCategory.SCOPE_1_DIRECT]: "777" },
+      }),
+    );
+    expect(refreshed).toContain(": 777");
+    expect(refreshed).not.toContain("1235000");
+    expect(refreshed.startsWith("敘述。")).toBe(true);
+  });
+});

--- a/src/__tests__/carbon_report_table.test.ts
+++ b/src/__tests__/carbon_report_table.test.ts
@@ -1,0 +1,170 @@
+// Info: (20260720 - Emily) #23 報告數據表格產生器測試:決定性輸出、LLM 表格丟棄、注入/替換、凍結、徽章三態
+
+import { describe, it, expect } from "@jest/globals";
+import {
+  buildCarbonDataTable,
+  stripLlmTables,
+  injectDataTable,
+  hasInjectedDataTable,
+  deriveDataBadgeState,
+  CarbonDataBadgeStateEnum,
+  CARBON_DATA_TABLE_START,
+  CARBON_DATA_TABLE_END,
+} from "@/lib/carbon_report_table.builder";
+import {
+  ArticulationStatusEnum,
+  ArticulationViolationReasonEnum,
+} from "@/constants/carbon_articulation";
+import { GhgProtocolCategory } from "@/constants/esg";
+import { IComputedLedger } from "@/types/carbon_chatbot.types";
+
+const buildLedger = (
+  overrides?: Partial<IComputedLedger>,
+): IComputedLedger => ({
+  entries: [
+    {
+      activityKey: "k1",
+      scopeCategory: GhgProtocolCategory.SCOPE_2_INDIRECT,
+      sourceName: "外購電力",
+      quantityRaw: "2,500,000",
+      convertedQuantity: "2500000",
+      convertedUnit: "KWH",
+      co2eKg: "1235000",
+      factor: {
+        factorId: "f1",
+        name: "台電電力係數",
+        value: "0.494",
+        unit: "度(kwh)",
+        source: "台灣電力公司 2024",
+      },
+    },
+  ],
+  pending: [],
+  scopeSubtotals: {
+    [GhgProtocolCategory.SCOPE_2_INDIRECT]: "1235000",
+  },
+  totalCo2eKg: "1235000",
+  computedAt: "2026-07-20T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("buildCarbonDataTable", () => {
+  it("should render engine figures verbatim with factor provenance (zero fabrication)", () => {
+    const table = buildCarbonDataTable(buildLedger());
+    // Info: (20260720 - Emily) 數字與 #21 引擎產出精確一致(千分位格式化,無 number 運算)
+    expect(table).toContain("1,235,000");
+    expect(table).toContain("0.494");
+    expect(table).toContain("台灣電力公司 2024");
+    expect(table).toContain(CARBON_DATA_TABLE_START);
+    expect(table).toContain(CARBON_DATA_TABLE_END);
+    // Info: (20260720 - Emily) 同輸入同輸出(決定性)
+    expect(buildCarbonDataTable(buildLedger())).toBe(table);
+  });
+
+  it("should freeze the table with an audit warning on mass conservation violation", () => {
+    const table = buildCarbonDataTable(
+      buildLedger({
+        articulation: {
+          status: ArticulationStatusEnum.VIOLATED,
+          violations: [
+            {
+              materialName: "柴油",
+              unit: "LITER",
+              reason:
+                ArticulationViolationReasonEnum.MASS_GAP_EXCEEDS_TOLERANCE,
+              expectedConsumption: "150",
+              actualConsumption: "200",
+              gap: "50",
+            },
+          ],
+          warnings: [],
+          checkedAt: "2026-07-20T00:00:00.000Z",
+        },
+      }),
+    );
+    expect(table).toContain("凍結");
+    // Info: (20260720 - Emily) 凍結時不得輸出任何數據表格列
+    expect(table).not.toContain("| 外購電力");
+  });
+
+  it("should render an insufficiency placeholder instead of an empty table", () => {
+    const table = buildCarbonDataTable(undefined);
+    expect(table).toContain("資料不足");
+    expect(table).not.toContain("| ---");
+  });
+
+  it("should note pending records excluded from the table", () => {
+    const table = buildCarbonDataTable(
+      buildLedger({
+        pending: [
+          { activityKey: "k2", sourceName: "柴油", reason: "NO_FACTOR_MATCH" },
+        ],
+      }),
+    );
+    expect(table).toContain("1 ");
+    expect(table).toContain("待補係數");
+  });
+});
+
+describe("stripLlmTables", () => {
+  it("should drop LLM-fabricated tables but keep narrative and fenced code", () => {
+    const content = [
+      "本期排放概況說明。",
+      "| 範疇 | 排放量 |",
+      "| --- | --- |",
+      "| Scope 1 | 999999 |",
+      "```",
+      "| 程式碼區塊內的表格照留 |",
+      "```",
+      "結尾敘述。",
+    ].join("\n");
+    const stripped = stripLlmTables(content);
+    expect(stripped).not.toContain("999999");
+    expect(stripped).toContain("本期排放概況說明。");
+    expect(stripped).toContain("| 程式碼區塊內的表格照留 |");
+    expect(stripped).toContain("結尾敘述。");
+  });
+});
+
+describe("injectDataTable / hasInjectedDataTable", () => {
+  it("should append when absent and replace in place on recompute (narrative untouched)", () => {
+    const narrative = "敘述文字。";
+    const v1 = injectDataTable(narrative, buildCarbonDataTable(buildLedger()));
+    expect(hasInjectedDataTable(v1)).toBe(true);
+    expect(v1.startsWith("敘述文字。")).toBe(true);
+
+    // Info: (20260720 - Emily) 重算後替換錨點區塊:敘述零改動,新數字生效
+    const updated = buildCarbonDataTable(
+      buildLedger({ totalCo2eKg: "999", scopeSubtotals: { S2: "999" } }),
+    );
+    const v2 = injectDataTable(v1, updated);
+    expect(v2).toContain("999");
+    expect(v2).not.toContain("1,235,000");
+    expect(v2.startsWith("敘述文字。")).toBe(true);
+    // Info: (20260720 - Emily) 錨點只有一組(替換非疊加)
+    expect(v2.split(CARBON_DATA_TABLE_START)).toHaveLength(2);
+  });
+});
+
+describe("deriveDataBadgeState", () => {
+  it("should adjudicate the three states deterministically", () => {
+    expect(deriveDataBadgeState(undefined)).toBe(
+      CarbonDataBadgeStateEnum.INSUFFICIENT,
+    );
+    expect(deriveDataBadgeState(buildLedger())).toBe(
+      CarbonDataBadgeStateEnum.RECONCILED,
+    );
+    expect(
+      deriveDataBadgeState(
+        buildLedger({
+          articulation: {
+            status: ArticulationStatusEnum.VIOLATED,
+            violations: [],
+            warnings: [],
+            checkedAt: "2026-07-20T00:00:00.000Z",
+          },
+        }),
+      ),
+    ).toBe(CarbonDataBadgeStateEnum.VIOLATED);
+  });
+});

--- a/src/__tests__/carbon_report_table.test.ts
+++ b/src/__tests__/carbon_report_table.test.ts
@@ -134,8 +134,14 @@ describe("injectDataTable / hasInjectedDataTable", () => {
     expect(v1.startsWith("敘述文字。")).toBe(true);
 
     // Info: (20260720 - Emily) 重算後替換錨點區塊:敘述零改動,新數字生效
+    // Info: (20260720 - Emily) entries 明細也要換新值,否則明細列仍印舊 co2e(測試資料須自洽)
+    const baseLedger = buildLedger();
     const updated = buildCarbonDataTable(
-      buildLedger({ totalCo2eKg: "999", scopeSubtotals: { S2: "999" } }),
+      buildLedger({
+        entries: [{ ...baseLedger.entries[0], co2eKg: "999" }],
+        totalCo2eKg: "999",
+        scopeSubtotals: { S2: "999" },
+      }),
     );
     const v2 = injectDataTable(v1, updated);
     expect(v2).toContain("999");

--- a/src/app/api/v1/chat/carbon/calculate/route.ts
+++ b/src/app/api/v1/chat/carbon/calculate/route.ts
@@ -1,6 +1,7 @@
 // Info: (20260716 - Emily) 決定論 CO2e 計算端點(#6519):活動明細 → 計算總表(含係數快照與待補清單)
 // Info: (20260716 - Emily) 純端口:授權 → 限流(READ,無 LLM 呼叫) → 驗證 → facade;
 // Info: (20260716 - Emily) 計算為無狀態決定論(冪等),結果由前端合併進 E2EE state,server 不落地明文
+// Info: (20260720 - Emily) #6520 同請求附帶庫存紀錄時一併執行質量守恆勾稽,結果掛 ledger.articulation
 
 import { NextRequest } from "next/server";
 import { logger } from "@/lib/utils/logger";
@@ -11,6 +12,7 @@ import { jsonOk, jsonFail } from "@/lib/utils/response";
 import { API_ERRORS, ApiError } from "@/lib/utils/error_dictionary";
 import { CarbonCalculateRequestSchema } from "@/validators";
 import { CarbonCalculationService } from "@/services/carbon_calculation.service";
+import { CarbonArticulationService } from "@/services/carbon_articulation.service";
 
 export async function POST(request: NextRequest) {
   try {
@@ -41,6 +43,11 @@ export async function POST(request: NextRequest) {
 
     const service = new CarbonCalculationService();
     const ledger = await service.computeLedger(parsed.data.activities);
+    // Info: (20260720 - Emily) #6520 守恆勾稽(純決定性,無額外 I/O):violation 不擋計算,凍結交由步驟機/報告端裁決
+    ledger.articulation = new CarbonArticulationService().check(
+      parsed.data.activities,
+      parsed.data.stockRecords ?? [],
+    );
     return jsonOk({ ledger });
   } catch (error) {
     if (error instanceof ApiError) {

--- a/src/app/api/v1/chat/carbon/route.ts
+++ b/src/app/api/v1/chat/carbon/route.ts
@@ -122,7 +122,8 @@ export async function POST(request: NextRequest) {
 
     // Info: (20260714 - Emily) 結構化回覆: 對話內容 + 段落完成訊號(readyParagraphId 已經白名單裁決)
     // Info: (20260716 - Emily) #6518:extraction 為已裁決的事實萃取，回帶前端合併進盤查狀態帳本
-    const { reply, readyParagraphId, extraction, revisionParagraphId } =
+    // Info: (20260720 - Emily) #51 chartRequest 為已裁決的圖表請求(雙 enum 白名單),透傳前端由模板產圖
+    const { reply, readyParagraphId, extraction, revisionParagraphId, chartRequest } =
       await chatService.generateCarbonChatbotStructuredResponse(
         historyForAi,
         currentStep,
@@ -244,6 +245,7 @@ export async function POST(request: NextRequest) {
         extraction,
         attachmentActivities,
         revisionParagraphId,
+        chartRequest,
         attachmentFacts,
       });
     }
@@ -255,6 +257,7 @@ export async function POST(request: NextRequest) {
       extraction,
       attachmentActivities,
       revisionParagraphId,
+      chartRequest,
       attachmentFacts,
     });
   } catch (error) {

--- a/src/app/user/carbon_chatbot/page.tsx
+++ b/src/app/user/carbon_chatbot/page.tsx
@@ -46,6 +46,7 @@ export default function CarbonChatbotPage() {
     reportStats,
     accountBooks,
     activeSessionAccess,
+    dataBadgeState,
     fetchBookSessions,
     masterKey,
     inventoryState,
@@ -132,6 +133,7 @@ export default function CarbonChatbotPage() {
           readOnly={!activeSessionAccess.canEdit}
           onImportReport={importReportFile}
           onRenameDocument={renameReportDocument}
+          dataBadgeState={dataBadgeState}
         />
 
         {/* Info: (20260716 - Emily) UAT 重疊修正:左下浮窗改單一堆疊容器(活動帳本在上、進度在下),

--- a/src/components/carbon_chatbot/activity_ledger.tsx
+++ b/src/components/carbon_chatbot/activity_ledger.tsx
@@ -3,9 +3,10 @@
 // Info: (20260716 - Emily) 預設收合為藥丸(RWD 教訓: 浮窗不可遮擋報告視線)
 
 import { useState } from "react";
-import { ClipboardList, Minus } from "lucide-react";
+import { ClipboardList, Minus, AlertTriangle, ShieldCheck } from "lucide-react";
 import { ICarbonInventoryState } from "@/types/carbon_chatbot.types";
 import { activityDedupeKey } from "@/lib/carbon_inventory";
+import { ArticulationStatusEnum } from "@/constants/carbon_articulation";
 import { useTranslation } from "@/i18n/i18n_context";
 
 export interface IActivityLedgerProps {
@@ -131,6 +132,46 @@ export function ActivityLedger({
           <span className="font-mono">{ledger.totalCo2eKg} kgCO2e</span>
         </div>
       )}
+
+      {/* Info: (20260720 - Emily) #6520 質量守恆勾稽:violation 明細透明呈現(等式兩側值,審計可追溯) */}
+      {ledger?.articulation?.status === ArticulationStatusEnum.PASSED && (
+        <div className="mt-1.5 flex items-center gap-1.5 rounded-lg bg-emerald-50 px-2 py-1.5 text-[11px] font-bold text-emerald-700">
+          <ShieldCheck size={12} className="shrink-0" />
+          {t("carbon_chatbot.articulation_passed")}
+        </div>
+      )}
+      {(ledger?.articulation?.violations ?? []).map((violation) => (
+        <div
+          key={`${violation.materialName}-${violation.unit}`}
+          className="mt-1.5 rounded-lg bg-red-50 px-2 py-1.5 text-[11px] text-red-700"
+        >
+          <div className="flex items-center gap-1.5 font-bold">
+            <AlertTriangle size={12} className="shrink-0" />
+            {t("carbon_chatbot.articulation_violation", {
+              material: violation.materialName,
+            })}
+          </div>
+          <div className="mt-0.5 font-mono text-[10px]">
+            {t("carbon_chatbot.articulation_equation", {
+              expected: violation.expectedConsumption,
+              actual: violation.actualConsumption,
+              gap: violation.gap,
+              unit: violation.unit,
+            })}
+          </div>
+        </div>
+      ))}
+      {(ledger?.articulation?.warnings ?? []).map((warning) => (
+        <div
+          key={warning.activityKey}
+          className="mt-1.5 flex items-center gap-1.5 rounded-lg bg-amber-50 px-2 py-1.5 text-[11px] font-bold text-amber-700"
+        >
+          <AlertTriangle size={12} className="shrink-0" />
+          {t("carbon_chatbot.articulation_plausibility_warning", {
+            source: warning.sourceName,
+          })}
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/carbon_chatbot/carbon_report_preview.tsx
+++ b/src/components/carbon_chatbot/carbon_report_preview.tsx
@@ -22,6 +22,7 @@ import {
   buildSectionHeadingByTitle,
   stripLeadingSectionHeading,
 } from "@/constants/carbon_report_outline";
+import { CarbonDataBadgeStateEnum } from "@/lib/carbon_report_table.builder";
 import { ReportToolbar } from "@/components/carbon_chatbot/report_toolbar";
 import { OutlineRail } from "@/components/carbon_chatbot/outline_rail";
 import { OutlineDrawer } from "@/components/carbon_chatbot/outline_drawer";
@@ -49,6 +50,8 @@ interface ICarbonReportPreviewProps {
   onImportReport?: (file: File) => void;
   // Info: (20260716 - Emily) 報告檔名改名(透傳工具列)
   onRenameDocument?: (documentName: string) => void;
+  // Info: (20260720 - Emily) #23 數據段落勾稽三態(透傳 OutlineDrawer → OutlineTree)
+  dataBadgeState?: CarbonDataBadgeStateEnum;
 }
 
 // Info: (20260713 - Tzuhan) 渲染全部 33 段:已生成者顯示內容,未生成者顯示灰色佔位區塊,確保跳段永遠有落點且報告骨架一眼可見
@@ -63,13 +66,12 @@ const generateMarkdownFromParagraphs = (
     return (
       // ToDo: (20260713 - Luphia) 報告預覽 markdown 表頭為硬編中文，如需多語系報告請改走 t()
       `# ${session.reportData?.title || ""}\n\n## ${session.reportData?.section || ""}\n\n### 溫室氣體排放量摘要\n\n| 類別 (ISO Category) | 來源說明 | 排放量 (tCO2e) |\n| --- | --- | --- |\n` +
+      // Info: (20260720 - Emily) #23 移除 .toFixed(numerical_precision_guideline):
+      // Info: (20260720 - Emily) emissions/totalEmissions 為引擎字串化 Decimal,直接渲染
       (session.reportData?.categories
-        ?.map(
-          (c) =>
-            `| **${c.name}** | ${c.description} | ${c.emissions.toFixed(2)} |`,
-        )
+        ?.map((c) => `| **${c.name}** | ${c.description} | ${c.emissions} |`)
         .join("\n") || "") +
-      `\n\n**TOTAL GROSS EMISSIONS: ${session.reportData?.totalEmissions?.toFixed(2) || 0}**`
+      `\n\n**TOTAL GROSS EMISSIONS: ${session.reportData?.totalEmissions || "0"}**`
     );
   }
 
@@ -103,6 +105,7 @@ export default function CarbonReportPreview({
   readOnly = false,
   onImportReport = undefined,
   onRenameDocument = undefined,
+  dataBadgeState = undefined,
 }: ICarbonReportPreviewProps) {
   const { t } = useTranslation();
   const [, setErrorModal] = useState({ isOpen: false, message: "" });
@@ -277,6 +280,7 @@ export default function CarbonReportPreview({
             onClose={() => setIsDrawerOpen(false)}
             draftingParagraphId={draftingParagraphId}
             onGenerateDraft={onGenerateDraft}
+            dataBadgeState={dataBadgeState}
           />
         )}
 

--- a/src/components/carbon_chatbot/chat_input.tsx
+++ b/src/components/carbon_chatbot/chat_input.tsx
@@ -177,7 +177,9 @@ export function ChatInput({
           className={`mx-auto mb-2 flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs font-bold ${
             draftNotice.type === "loading"
               ? "bg-orange-50 text-[#e04f00]"
-              : "bg-red-50 text-red-600"
+              : draftNotice.type === "info"
+                ? "bg-teal-50 text-teal-700"
+                : "bg-red-50 text-red-600"
           }`}
         >
           {draftNotice.type === "loading" && (

--- a/src/components/carbon_chatbot/outline_drawer.tsx
+++ b/src/components/carbon_chatbot/outline_drawer.tsx
@@ -5,6 +5,7 @@
 
 import { X } from "lucide-react";
 import { IReportParagraph } from "@/types/carbon_chatbot.types";
+import { CarbonDataBadgeStateEnum } from "@/lib/carbon_report_table.builder";
 import { OutlineTree } from "@/components/carbon_chatbot/outline_tree";
 import { useTranslation } from "@/i18n/i18n_context";
 
@@ -17,6 +18,8 @@ interface IOutlineDrawerProps {
   // Info: (20260714 - Emily) AI 段落草稿生成(透傳給 OutlineTree)
   draftingParagraphId?: string | null;
   onGenerateDraft?: (paragraphId: string) => void;
+  // Info: (20260720 - Emily) #23 數據段落勾稽三態(透傳給 OutlineTree)
+  dataBadgeState?: CarbonDataBadgeStateEnum;
 }
 
 export function OutlineDrawer({
@@ -27,6 +30,7 @@ export function OutlineDrawer({
   onClose,
   draftingParagraphId = null,
   onGenerateDraft = undefined,
+  dataBadgeState = undefined,
 }: IOutlineDrawerProps) {
   const { t } = useTranslation();
 
@@ -54,6 +58,7 @@ export function OutlineDrawer({
         onToggleVerified={onToggleVerified}
         draftingParagraphId={draftingParagraphId}
         onGenerateDraft={onGenerateDraft}
+        dataBadgeState={dataBadgeState}
       />
     </div>
   );

--- a/src/components/carbon_chatbot/outline_tree.tsx
+++ b/src/components/carbon_chatbot/outline_tree.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { IReportParagraph } from "@/types/carbon_chatbot.types";
 import { CARBON_REPORT_CHAPTERS } from "@/constants/carbon_report_outline";
+import { CarbonDataBadgeStateEnum } from "@/lib/carbon_report_table.builder";
 import { useTranslation } from "@/i18n/i18n_context";
 
 interface IOutlineTreeProps {
@@ -26,6 +27,8 @@ interface IOutlineTreeProps {
   // Info: (20260714 - Emily) AI 段落草稿生成:正在生成的段落 id(同時間僅一段)與觸發 callback
   draftingParagraphId?: string | null;
   onGenerateDraft?: (paragraphId: string) => void;
+  // Info: (20260720 - Emily) #23 數據段落勾稽三態(已勾稽 ✓/守恆違反 ⚠/數據不足),由 ledger 決定性裁決
+  dataBadgeState?: CarbonDataBadgeStateEnum;
 }
 
 const statusIcon = (paragraph: IReportParagraph, isActive: boolean) => {
@@ -43,8 +46,25 @@ export function OutlineTree({
   onToggleVerified,
   draftingParagraphId = null,
   onGenerateDraft = undefined,
+  dataBadgeState = CarbonDataBadgeStateEnum.INSUFFICIENT,
 }: IOutlineTreeProps) {
   const { t } = useTranslation();
+  // Info: (20260720 - Emily) #23 三態徽章樣式:teal=已勾稽、red=守恆違反、gray=數據不足
+  const dataBadge =
+    dataBadgeState === CarbonDataBadgeStateEnum.RECONCILED
+      ? {
+          className: "shrink-0 text-teal-600",
+          title: t("carbon_chatbot.data_badge_reconciled"),
+        }
+      : dataBadgeState === CarbonDataBadgeStateEnum.VIOLATED
+        ? {
+            className: "shrink-0 text-red-500",
+            title: t("carbon_chatbot.data_badge_violated"),
+          }
+        : {
+            className: "shrink-0 text-gray-300",
+            title: t("carbon_chatbot.data_badge_insufficient"),
+          };
   const activeChapterId = paragraphs.find(
     (p) => p.id === activeParagraphId,
   )?.chapterId;
@@ -150,12 +170,10 @@ export function OutlineTree({
                       )}
 
                       {/* Info: (20260713 - Tzuhan) 數據段落標記:數字由後端決定論管線勾稽,非 LLM 產出 */}
+                      {/* Info: (20260720 - Emily) #23 三態化:顏色/提示反映勾稽真實狀態,不再是不實聲明 */}
                       {p.isDataDriven && (
-                        <span title={t("carbon_chatbot.data_driven_badge")}>
-                          <Database
-                            size={12}
-                            className="shrink-0 text-teal-600"
-                          />
+                        <span title={dataBadge.title}>
+                          <Database size={12} className={dataBadge.className} />
                         </span>
                       )}
 

--- a/src/constants/carbon_articulation.ts
+++ b/src/constants/carbon_articulation.ts
@@ -1,0 +1,70 @@
+// Info: (20260720 - Emily) 質量守恆勾稽護欄常數(#6520 / issue 22)
+// Info: (20260720 - Emily) 核心等式:期初庫存 + 本期採購 = 本期投入(消耗) + 期末庫存(± 損耗容差)
+// Info: (20260720 - Emily) 全部為決定性常數 — 檢核門檻不由 LLM 判斷(esg_methodology_mapping 防漂綠護欄)
+
+import { MeasurementUnit } from "@/constants/enums";
+
+/**
+ * Info: (20260720 - Emily) 方法論允許的損耗率容差(Decimal 字串,嚴禁 number 運算):
+ * |等式缺口| ≤ 預期消耗 × 本值 → 視為合理損耗放行並記錄;超出 → violation 凍結。
+ */
+export const LOSS_RATIO_TOLERANCE = "0.05";
+
+/**
+ * Info: (20260720 - Emily) 可盤點物料單位(質量/體積):燃料、原物料 — 適用守恆檢核。
+ * 電力/運輸等流量型單位不可盤點,改跑合理性區間檢核(超界僅警示不凍結)。
+ */
+export const STOCKABLE_UNITS: readonly MeasurementUnit[] = [
+  MeasurementUnit.KG,
+  MeasurementUnit.GRAM,
+  MeasurementUnit.TONNE,
+  MeasurementUnit.LITER,
+  MeasurementUnit.GALLON,
+  MeasurementUnit.M3,
+] as const;
+
+/**
+ * Info: (20260720 - Emily) 非庫存類活動數據的合理性上限(單一企業單年,保守放寬的物理量級邊界):
+ * 超出僅產生警示(資料仍是事實,可能是集團級數據),不凍結入帳。值為 Decimal 字串。
+ */
+export const PLAUSIBILITY_MAX_BY_UNIT: Partial<Record<MeasurementUnit, string>> =
+  {
+    // Info: (20260720 - Emily) 100 億度電/年 ≈ 台灣全國用電的 3.5%,單一企業超出即極可疑
+    [MeasurementUnit.KWH]: "10000000000",
+    [MeasurementUnit.MWH]: "10000000",
+    [MeasurementUnit.GJ]: "40000000",
+    // Info: (20260720 - Emily) 運輸活動(公里/延噸公里/人公里)
+    [MeasurementUnit.KM]: "1000000000",
+    [MeasurementUnit.TKM]: "100000000000",
+    [MeasurementUnit.PKM]: "100000000000",
+  };
+
+// Info: (20260720 - Emily) 單次檢核的庫存紀錄筆數上限(輸入護欄,對齊 CARBON_CALCULATE_MAX_ACTIVITIES 量級)
+export const CARBON_ARTICULATION_MAX_STOCK_RECORDS = 50;
+
+// Info: (20260720 - Emily) 勾稽結果狀態(決定性列舉;REVIEW 步驟出口與 #23 報告數據段落凍結依此裁決)
+export enum ArticulationStatusEnum {
+  // Info: (20260720 - Emily) 有庫存紀錄且全數通過(含容差內損耗)
+  PASSED = "PASSED",
+  // Info: (20260720 - Emily) 至少一筆守恆違反 → 報告數據段落凍結、費思追問澄清
+  VIOLATED = "VIOLATED",
+  // Info: (20260720 - Emily) 無可盤點庫存紀錄(純電力/運輸盤查屬合法情境),守恆檢核不適用
+  NOT_APPLICABLE = "NOT_APPLICABLE",
+}
+
+// Info: (20260720 - Emily) 守恆違反原因(決定性列舉,UI 對應文案)
+export enum ArticulationViolationReasonEnum {
+  // Info: (20260720 - Emily) |期初+採購-期末-消耗| 超出損耗容差
+  MASS_GAP_EXCEEDS_TOLERANCE = "MASS_GAP_EXCEEDS_TOLERANCE",
+  // Info: (20260720 - Emily) 期末 > 期初+採購:物理不可能(庫存無中生有)
+  NEGATIVE_EXPECTED_CONSUMPTION = "NEGATIVE_EXPECTED_CONSUMPTION",
+  // Info: (20260720 - Emily) 庫存與消耗紀錄單位跨量綱,無法對齊驗證
+  UNIT_MISMATCH = "UNIT_MISMATCH",
+  // Info: (20260720 - Emily) 庫存紀錄數值無法決定性解析
+  UNPARSABLE_QUANTITY = "UNPARSABLE_QUANTITY",
+}
+
+// Info: (20260720 - Emily) 合理性警示原因(僅警示不凍結)
+export enum ArticulationWarningReasonEnum {
+  QUANTITY_EXCEEDS_PLAUSIBLE_MAX = "QUANTITY_EXCEEDS_PLAUSIBLE_MAX",
+}

--- a/src/constants/carbon_chatbot.session.ts
+++ b/src/constants/carbon_chatbot.session.ts
@@ -44,7 +44,8 @@ export const createChatSession = (
     section: "",
     categories: [],
     paragraphs: buildInitialParagraphs(),
-    totalEmissions: 0,
+    // Info: (20260720 - Emily) #23 字串化 Decimal(接 computedLedger 真值前的初始值)
+    totalEmissions: "0",
   },
 });
 

--- a/src/constants/carbon_report_charts.ts
+++ b/src/constants/carbon_report_charts.ts
@@ -1,0 +1,26 @@
+// Info: (20260720 - Emily) 報告圖表模板白名單(#51):可用圖型 × 資料切面的決定性列舉
+// Info: (20260720 - Emily) LLM 只裁決「使用者要哪張圖、放哪段」(雙 enum 鎖死);
+// Info: (20260720 - Emily) 圖表數值一律由模板函式從 computedLedger 產出,LLM 零參與填值
+// Info: (20260720 - Emily) 註:TREND_LINE(期間趨勢)因單期 ledger 無時間序列刻意不上架 —
+// Info: (20260720 - Emily) 永不可滿足的模板即地雷;待多期資料模型(後續 issue)一併實作
+// Info: (20260720 - Emily) 註:EMISSION_SANKEY(憑證→排放源→Scope 碳流量)依賴 #53 憑證聯動,屆時併入本列舉
+
+export enum CarbonChartTemplateEnum {
+  // Info: (20260720 - Emily) 各範疇占比圓餅圖(mermaid pie)
+  SCOPE_PIE = "SCOPE_PIE",
+  // Info: (20260720 - Emily) 各範疇長條圖(mermaid xychart-beta bar)
+  SCOPE_BAR = "SCOPE_BAR",
+  // Info: (20260720 - Emily) 排放源明細表(markdown 表格,復用 #23 表格產生器)
+  SOURCE_TABLE = "SOURCE_TABLE",
+}
+
+// Info: (20260720 - Emily) 圖表區塊錨點(HTML 註解,渲染不可見):重算連動依此替換,敘述零改動
+export const CARBON_CHART_ANCHOR_PREFIX = "carbon-chart";
+
+export const buildChartAnchorStart = (
+  templateId: CarbonChartTemplateEnum,
+): string => `<!-- ${CARBON_CHART_ANCHOR_PREFIX}:${templateId}:start -->`;
+
+export const buildChartAnchorEnd = (
+  templateId: CarbonChartTemplateEnum,
+): string => `<!-- ${CARBON_CHART_ANCHOR_PREFIX}:${templateId}:end -->`;

--- a/src/hooks/use_carbon_chat.ts
+++ b/src/hooks/use_carbon_chat.ts
@@ -24,6 +24,14 @@ import {
   deriveDataBadgeState,
   type ICarbonDataTableLabels,
 } from "@/lib/carbon_report_table.builder";
+import {
+  buildCarbonChartBlock,
+  insertCarbonChartBlock,
+  hasCarbonChartBlocks,
+  refreshCarbonChartBlocks,
+  type ICarbonChartLabels,
+} from "@/lib/carbon_report_chart.builder";
+import { CarbonChartTemplateEnum } from "@/constants/carbon_report_charts";
 import { formatFileSize } from "@/lib/utils/common";
 import {
   CARBON_REPORT_OUTLINE,
@@ -649,6 +657,18 @@ export const useCarbonChat = () => {
   const dataBadgeState = deriveDataBadgeState(
     activeInventoryState?.computedLedger,
   );
+
+  // Info: (20260720 - Emily) #51 圖表文案(i18n;數值本身一律引擎產出,與語言無關)
+  const chartLabels: ICarbonChartLabels = useMemo(
+    () => ({
+      pieTitle: t("carbon_chatbot.chart_scope_pie_title"),
+      barTitle: t("carbon_chatbot.chart_scope_bar_title"),
+      axisCo2e: "kgCO2e",
+      insufficient: t("carbon_chatbot.chart_insufficient"),
+      frozen: t("carbon_chatbot.chart_frozen"),
+    }),
+    [t],
+  );
   useEffect(() => {
     if (!activeInventoryState) return undefined;
     if (!inventoryRestoredChannelsRef.current.has(chatChannel))
@@ -1264,6 +1284,70 @@ export const useCarbonChat = () => {
     setPendingRevision(null);
   }, []);
 
+  /**
+   * Info: (20260720 - Emily) #51 插入模板圖表至段落:
+   * 圖表區塊由白名單模板從 computedLedger 決定性產出(LLM 只裁決了「哪張圖、放哪段」);
+   * 同模板已存在 → 原地替換不疊加;rawMarkdown 同步 patch(權威來源);插入後跳段高亮
+   */
+  const insertChartIntoParagraph = useCallback(
+    (templateId: CarbonChartTemplateEnum, paragraphId: string) => {
+      const block = buildCarbonChartBlock(
+        templateId,
+        activeInventoryState?.computedLedger,
+        chartLabels,
+        dataTableLabels,
+      );
+      setSessionsData((prev) => {
+        const session = prev[activeSessionId];
+        const reportData = session?.reportData;
+        if (!reportData?.paragraphs) return prev;
+        const target = reportData.paragraphs.find((p) => p.id === paragraphId);
+        if (!target) return prev;
+        const nextContent = insertCarbonChartBlock(
+          target.content,
+          templateId,
+          block,
+        );
+        const nextRaw = reportData.rawMarkdown
+          ? patchMarkdownSection(
+              reportData.rawMarkdown,
+              target.title,
+              nextContent,
+            )
+          : reportData.rawMarkdown;
+        return {
+          ...prev,
+          [activeSessionId]: {
+            ...session,
+            reportData: {
+              ...reportData,
+              rawMarkdown: nextRaw,
+              paragraphs: reportData.paragraphs.map((p) =>
+                p.id === paragraphId
+                  ? {
+                      ...p,
+                      content: nextContent,
+                      isCompleted: true,
+                      // Info: (20260720 - Emily) 內容更新即重置查核(零信任)
+                      isVerified: false,
+                    }
+                  : p,
+              ),
+            },
+          },
+        };
+      });
+      jumpToReportParagraph(paragraphId);
+    },
+    [
+      activeSessionId,
+      activeInventoryState?.computedLedger,
+      chartLabels,
+      dataTableLabels,
+      jumpToReportParagraph,
+    ],
+  );
+
   // Info: (20260714 - Emily) 將草稿寫入 reportData:標記完成、重置查核(單一寫入點,對話生成與附件管線共用)
   // Info: (20260714 - Emily) content 只存內文;`### {標題}` 標頭由報告預覽組稿時產生,格式變更不需資料遷移
   // Info: (20260714 - Emily) onlyIfEmpty:歷史還原補寫時只填空白段落,避免覆蓋使用者後續的編輯
@@ -1363,10 +1447,20 @@ export const useCarbonChat = () => {
       let nextRaw = reportData.rawMarkdown;
       let paragraphsChanged = false;
       const nextParagraphs = reportData.paragraphs.map((p) => {
-        if (!p.isDataDriven || !p.content || !hasInjectedDataTable(p.content)) {
-          return p;
+        if (!p.content) return p;
+        let nextContent = p.content;
+        if (p.isDataDriven && hasInjectedDataTable(nextContent)) {
+          nextContent = injectDataTable(nextContent, tableBlock);
         }
-        const nextContent = injectDataTable(p.content, tableBlock);
+        // Info: (20260720 - Emily) #51 模板圖表同步重建(任何段落;白名單逐一檢查,敘述零改動)
+        if (hasCarbonChartBlocks(nextContent)) {
+          nextContent = refreshCarbonChartBlocks(
+            nextContent,
+            ledger,
+            chartLabels,
+            dataTableLabels,
+          );
+        }
         if (nextContent === p.content) return p;
         paragraphsChanged = true;
         if (nextRaw) {
@@ -1417,6 +1511,7 @@ export const useCarbonChat = () => {
     chatChannel,
     activeSessionId,
     dataTableLabels,
+    chartLabels,
     t,
   ]);
 
@@ -2112,6 +2207,10 @@ export const useCarbonChat = () => {
           extraction?: IInventoryExtraction | null;
           attachmentActivities?: IActivityRecord[];
           revisionParagraphId?: string | null;
+          chartRequest?: {
+            templateId: CarbonChartTemplateEnum;
+            paragraphId: string;
+          } | null;
           attachmentFacts?: IContextFact[];
         } | null;
       }>("/api/v1/chat/carbon", {
@@ -2171,6 +2270,14 @@ export const useCarbonChat = () => {
         );
       }
 
+      // Info: (20260720 - Emily) #51 圖表請求(已經雙 enum 白名單裁決):由模板從勾稽數據產圖插入
+      if (payload?.chartRequest) {
+        insertChartIntoParagraph(
+          payload.chartRequest.templateId,
+          payload.chartRequest.paragraphId,
+        );
+      }
+
       // Info: (20260712 - Luphia) 啟動等待逾時，避免「已發佈但未收到」時卡在 typing(回覆已回帶時為 no-op)
       // Info: (20260716 - Emily) 帶附件時管線含萃取/草稿生成,等待窗加長(UAT:30s 誤報系統錯誤)
       startReplyTimeout(
@@ -2219,6 +2326,7 @@ export const useCarbonChat = () => {
     applyInventoryExtraction,
     inventoryStates,
     requestParagraphRevision,
+    insertChartIntoParagraph,
   ]);
 
   // Info: (20260712 - Luphia) 進入 channel 的一次性手勢：解鎖金鑰(PRF) → 請後端做前置作業並經 Centrifugo 回傳招呼詞

--- a/src/hooks/use_carbon_chat.ts
+++ b/src/hooks/use_carbon_chat.ts
@@ -14,7 +14,16 @@ import {
   IInventoryExtraction,
   IActivityRecord,
   IComputedLedger,
+  IReportCategory,
 } from "@/types/carbon_chatbot.types";
+import {
+  buildCarbonDataTable,
+  stripLlmTables,
+  injectDataTable,
+  hasInjectedDataTable,
+  deriveDataBadgeState,
+  type ICarbonDataTableLabels,
+} from "@/lib/carbon_report_table.builder";
 import { formatFileSize } from "@/lib/utils/common";
 import {
   CARBON_REPORT_OUTLINE,
@@ -98,8 +107,9 @@ export type ReportSaveStatus = "saving" | "saved" | "error" | "local" | null;
 
 // Info: (20260714 - Emily) 草稿生成狀態列(顯示於輸入框上方): 生成中 loading、失敗短暫提示後自動消失
 // Info: (20260714 - Emily) 草稿為並行任務，失敗不以對話氣泡表達(氣泡先於回覆出現會造成 UX 混淆)
+// Info: (20260720 - Emily) #23 新增 info:數據表格隨活動數據自動更新的非阻斷提示
 export interface IDraftNotice {
-  type: "loading" | "error";
+  type: "loading" | "error" | "info";
   text: string;
 }
 
@@ -616,6 +626,29 @@ export const useCarbonChat = () => {
 
   // Info: (20260716 - Emily) #6518 盤查狀態 debounce 自動保存(前端加密 → PUT；樂觀鎖)
   const activeInventoryState = inventoryStates[chatChannel];
+
+  // Info: (20260720 - Emily) #23 數據表格文案(i18n;數字本身與語言無關,一律引擎字串)
+  const dataTableLabels: ICarbonDataTableLabels = useMemo(
+    () => ({
+      detailHeading: t("carbon_chatbot.report_table_detail_heading"),
+      colSource: t("carbon_chatbot.report_table_col_source"),
+      colScope: t("carbon_chatbot.report_table_col_scope"),
+      colQuantity: t("carbon_chatbot.report_table_col_quantity"),
+      colFactor: t("carbon_chatbot.report_table_col_factor"),
+      colCo2e: t("carbon_chatbot.report_table_col_co2e"),
+      subtotalHeading: t("carbon_chatbot.report_table_subtotal_heading"),
+      total: t("carbon_chatbot.report_table_total"),
+      insufficient: t("carbon_chatbot.report_table_insufficient"),
+      frozen: t("carbon_chatbot.report_table_frozen"),
+      pendingNote: t("carbon_chatbot.report_table_pending_note"),
+    }),
+    [t],
+  );
+
+  // Info: (20260720 - Emily) #23 數據段落勾稽徽章三態(目錄樹顯示;由 ledger 決定性裁決)
+  const dataBadgeState = deriveDataBadgeState(
+    activeInventoryState?.computedLedger,
+  );
   useEffect(() => {
     if (!activeInventoryState) return undefined;
     if (!inventoryRestoredChannelsRef.current.has(chatChannel))
@@ -1234,12 +1267,24 @@ export const useCarbonChat = () => {
   // Info: (20260714 - Emily) 將草稿寫入 reportData:標記完成、重置查核(單一寫入點,對話生成與附件管線共用)
   // Info: (20260714 - Emily) content 只存內文;`### {標題}` 標頭由報告預覽組稿時產生,格式變更不需資料遷移
   // Info: (20260714 - Emily) onlyIfEmpty:歷史還原補寫時只填空白段落,避免覆蓋使用者後續的編輯
+  // Info: (20260720 - Emily) #23 數據段落組裝制:LLM 只留敘述(夾帶表格一律丟棄),
+  // Info: (20260720 - Emily) 表格由 TS 從 computedLedger 決定性產出注入(守恆違反 → 凍結告警取代)
   const applyDraftToReport = useCallback(
     (draft: IParagraphDraft, options?: { onlyIfEmpty?: boolean }) => {
       const section = CARBON_REPORT_OUTLINE.find(
         (s) => s.id === draft.paragraphId,
       );
       if (!section) return;
+
+      const content = section.isDataDriven
+        ? injectDataTable(
+            stripLlmTables(draft.content),
+            buildCarbonDataTable(
+              activeInventoryState?.computedLedger,
+              dataTableLabels,
+            ),
+          )
+        : draft.content;
 
       setSessionsData((prev) => {
         const session = prev[activeSessionId];
@@ -1251,7 +1296,7 @@ export const useCarbonChat = () => {
           if (options?.onlyIfEmpty && p.content) return p;
           return {
             ...p,
-            content: draft.content,
+            content,
             isCompleted: true,
             // Info: (20260714 - Emily) 內容更新即重置查核狀態(零信任: 先有產出才有查核)
             isVerified: false,
@@ -1264,11 +1309,7 @@ export const useCarbonChat = () => {
         )?.title;
         const nextRaw =
           reportData.rawMarkdown && targetTitle
-            ? patchMarkdownSection(
-                reportData.rawMarkdown,
-                targetTitle,
-                draft.content,
-              )
+            ? patchMarkdownSection(reportData.rawMarkdown, targetTitle, content)
             : reportData.rawMarkdown;
 
         // Info: (20260716 - Emily) 純 immutable 構造(react-hooks/immutability):不對 spread 副本再賦值
@@ -1285,8 +1326,99 @@ export const useCarbonChat = () => {
         };
       });
     },
-    [activeSessionId],
+    [activeSessionId, activeInventoryState?.computedLedger, dataTableLabels],
   );
+
+  /**
+   * Info: (20260720 - Emily) #23 重算連動:computedLedger 更新 →
+   * 1. 已注入表格的數據段落自動重注入(敘述零改動,查核重置)
+   * 2. categories/totalEmissions 接引擎真值(字串化 Decimal,廢除空殼佔位)
+   * computedAt 戳記 guard 防重複執行;表格內容相同時不換參考(不觸發 autosave)
+   */
+  const lastLedgerStampRef = useRef<Map<string, string>>(new Map());
+  useEffect(() => {
+    const ledger = activeInventoryState?.computedLedger;
+    if (!ledger) return;
+    if (lastLedgerStampRef.current.get(chatChannel) === ledger.computedAt) {
+      return;
+    }
+    lastLedgerStampRef.current.set(chatChannel, ledger.computedAt);
+
+    const tableBlock = buildCarbonDataTable(ledger, dataTableLabels);
+    const nextCategories: IReportCategory[] = Object.entries(
+      ledger.scopeSubtotals,
+    ).map(([scope, subtotal]) => ({
+      id: scope,
+      name: scope,
+      description: "",
+      emissions: subtotal,
+    }));
+
+    let tableRefreshed = false;
+    setSessionsData((prev) => {
+      const session = prev[activeSessionId];
+      const reportData = session?.reportData;
+      if (!reportData?.paragraphs) return prev;
+
+      let nextRaw = reportData.rawMarkdown;
+      let paragraphsChanged = false;
+      const nextParagraphs = reportData.paragraphs.map((p) => {
+        if (!p.isDataDriven || !p.content || !hasInjectedDataTable(p.content)) {
+          return p;
+        }
+        const nextContent = injectDataTable(p.content, tableBlock);
+        if (nextContent === p.content) return p;
+        paragraphsChanged = true;
+        if (nextRaw) {
+          nextRaw = patchMarkdownSection(nextRaw, p.title, nextContent);
+        }
+        // Info: (20260720 - Emily) 數字變動即重置查核(零信任:數據更新需重新人工確認)
+        return { ...p, content: nextContent, isVerified: false };
+      });
+
+      const totalsChanged =
+        reportData.totalEmissions !== ledger.totalCo2eKg ||
+        JSON.stringify(reportData.categories) !==
+          JSON.stringify(nextCategories);
+      if (!paragraphsChanged && !totalsChanged) return prev;
+      tableRefreshed = paragraphsChanged;
+      return {
+        ...prev,
+        [activeSessionId]: {
+          ...session,
+          reportData: {
+            ...reportData,
+            rawMarkdown: nextRaw,
+            paragraphs: nextParagraphs,
+            categories: nextCategories,
+            totalEmissions: ledger.totalCo2eKg,
+          },
+        },
+      };
+    });
+
+    // Info: (20260720 - Emily) 高亮提示(非阻斷 info,自動消失):數據表格已隨活動數據更新
+    // Info: (20260720 - Emily) setState 後同步讀 flag:updater 於 React 18 同步執行,此處可安全讀取
+    if (tableRefreshed) {
+      setDraftNotice({
+        type: "info",
+        text: t("carbon_chatbot.data_table_refreshed"),
+      });
+      if (draftNoticeTimerRef.current) {
+        clearTimeout(draftNoticeTimerRef.current);
+      }
+      draftNoticeTimerRef.current = setTimeout(() => {
+        draftNoticeTimerRef.current = null;
+        setDraftNotice(null);
+      }, CARBON_DRAFT_NOTICE_DISMISS_MS);
+    }
+  }, [
+    activeInventoryState?.computedLedger,
+    chatChannel,
+    activeSessionId,
+    dataTableLabels,
+    t,
+  ]);
 
   // Info: (20260712 - Luphia) 載入歷史訊息（密文→以主私鑰解密）；before 省略為最新一頁，否則載入更舊一頁並前置
   const loadHistory = useCallback(
@@ -2244,6 +2376,8 @@ export const useCarbonChat = () => {
     masterKey: unlockedMasterKey,
     // Info: (20260716 - Emily) #6518 盤查狀態帳本(活動數據 + 決定性步驟),供記錄卡顯示
     inventoryState: activeInventoryState ?? createEmptyInventoryState(),
+    // Info: (20260720 - Emily) #23 數據段落勾稽徽章三態(已勾稽/守恆違反/數據不足)
+    dataBadgeState,
     activeParagraphId,
     jumpToParagraph,
     highlightedParagraphId,

--- a/src/hooks/use_carbon_chat.ts
+++ b/src/hooks/use_carbon_chat.ts
@@ -37,6 +37,7 @@ import {
   describeInventoryStep,
   applyComputedLedger,
   activityDedupeKey,
+  stockRecordDedupeKey,
 } from "@/lib/carbon_inventory";
 import {
   loadInventoryState,
@@ -668,8 +669,14 @@ export const useCarbonChat = () => {
     if (!activeInventoryState || activeInventoryState.activities.length === 0) {
       return;
     }
-    const signature = activeInventoryState.activities
-      .map(activityDedupeKey)
+    // Info: (20260720 - Emily) #6520 簽章納入庫存紀錄:期初/採購/期末變更也要重跑勾稽
+    const signature = [
+      ...activeInventoryState.activities.map(activityDedupeKey),
+      ...(activeInventoryState.stockRecords ?? []).map(
+        (r) =>
+          `stock:${stockRecordDedupeKey(r)}|${r.openingQuantity}|${r.purchasedQuantity}|${r.closingQuantity}`,
+      ),
+    ]
       .sort()
       .join(";");
     if (lastCalcSignatureRef.current.get(chatChannel) === signature) return;
@@ -680,7 +687,10 @@ export const useCarbonChat = () => {
       "/api/v1/chat/carbon/calculate",
       {
         method: "POST",
-        body: JSON.stringify({ activities: activeInventoryState.activities }),
+        body: JSON.stringify({
+          activities: activeInventoryState.activities,
+          stockRecords: activeInventoryState.stockRecords ?? [],
+        }),
       },
     )
       .then((res) => {

--- a/src/i18n/locales/en/carbon_chatbot.ts
+++ b/src/i18n/locales/en/carbon_chatbot.ts
@@ -173,6 +173,12 @@ export const carbonChatbot = {
     "Data section: mass conservation violated ⚠ (table frozen pending clarification)",
   data_badge_insufficient:
     "Data section: insufficient data (generated automatically once activity data is complete)",
+  chart_scope_pie_title: "Emissions share by scope (kgCO2e)",
+  chart_scope_bar_title: "Emissions by scope (kgCO2e)",
+  chart_insufficient:
+    "(Insufficient data — the chart will be generated automatically once activity data is complete)",
+  chart_frozen:
+    "⚠ Mass conservation check failed; the chart is frozen. Clarify the inventory gap in the chat and it will be generated automatically.",
   inventory_step_ORG_PROFILE: "Step: Organization profile (name/year)",
   inventory_step_ORG_BOUNDARY: "Step: Organizational boundary",
   inventory_step_EMISSION_SOURCES: "Step: Emission source identification",

--- a/src/i18n/locales/en/carbon_chatbot.ts
+++ b/src/i18n/locales/en/carbon_chatbot.ts
@@ -151,6 +151,28 @@ export const carbonChatbot = {
     "Opening + purchased - closing = {{expected}} {{unit}}, recorded consumption = {{actual}} {{unit}}, gap = {{gap}} {{unit}}",
   articulation_plausibility_warning:
     "Quantity exceeds a plausible range, please verify: {{source}}",
+  report_table_detail_heading: "Emission source details",
+  report_table_col_source: "Source",
+  report_table_col_scope: "Scope",
+  report_table_col_quantity: "Activity data",
+  report_table_col_factor: "Emission factor (source)",
+  report_table_col_co2e: "Emissions (kgCO2e)",
+  report_table_subtotal_heading: "Scope subtotals",
+  report_table_total: "Total emissions",
+  report_table_insufficient:
+    "(Insufficient data — the table will be generated automatically once activity data is complete)",
+  report_table_frozen:
+    "⚠ Mass conservation check failed; the data table is frozen. Clarify the inventory gap in the chat and the table will be generated automatically.",
+  report_table_pending_note:
+    "Note: {count} activity record(s) still await emission factors and are excluded from this table.",
+  data_table_refreshed:
+    "Data tables were refreshed from the activity ledger — please re-verify the affected sections",
+  data_badge_reconciled:
+    "Data section: reconciled ✓ (figures produced by the deterministic engine)",
+  data_badge_violated:
+    "Data section: mass conservation violated ⚠ (table frozen pending clarification)",
+  data_badge_insufficient:
+    "Data section: insufficient data (generated automatically once activity data is complete)",
   inventory_step_ORG_PROFILE: "Step: Organization profile (name/year)",
   inventory_step_ORG_BOUNDARY: "Step: Organizational boundary",
   inventory_step_EMISSION_SOURCES: "Step: Emission source identification",

--- a/src/i18n/locales/en/carbon_chatbot.ts
+++ b/src/i18n/locales/en/carbon_chatbot.ts
@@ -145,6 +145,12 @@ export const carbonChatbot = {
   activity_pending_factor:
     "⚠ Pending: no reliable factor or unit mismatch; no estimate will be fabricated",
   activity_total_co2e: "Total emissions (reconciled)",
+  articulation_passed: "Mass conservation check passed",
+  articulation_violation: "Mass conservation violated: {{material}}",
+  articulation_equation:
+    "Opening + purchased - closing = {{expected}} {{unit}}, recorded consumption = {{actual}} {{unit}}, gap = {{gap}} {{unit}}",
+  articulation_plausibility_warning:
+    "Quantity exceeds a plausible range, please verify: {{source}}",
   inventory_step_ORG_PROFILE: "Step: Organization profile (name/year)",
   inventory_step_ORG_BOUNDARY: "Step: Organizational boundary",
   inventory_step_EMISSION_SOURCES: "Step: Emission source identification",

--- a/src/i18n/locales/ja/carbon_chatbot.ts
+++ b/src/i18n/locales/ja/carbon_chatbot.ts
@@ -146,6 +146,12 @@ export const carbonChatbot = {
   activity_pending_factor:
     "⚠ 保留:信頼できる係数がないか単位不一致のため推定しません",
   activity_total_co2e: "総排出量(照合済み)",
+  articulation_passed: "質量保存チェックに合格しました",
+  articulation_violation: "質量保存違反：{{material}}",
+  articulation_equation:
+    "期首+購入-期末 = {{expected}} {{unit}}、記録上の消費 = {{actual}} {{unit}}、差異 = {{gap}} {{unit}}",
+  articulation_plausibility_warning:
+    "数量が妥当な範囲を超えています。ご確認ください：{{source}}",
   inventory_step_ORG_PROFILE: "ステップ:企業基本情報(名称/年度)",
   inventory_step_ORG_BOUNDARY: "ステップ:組織境界の設定",
   inventory_step_EMISSION_SOURCES: "ステップ:排出源の特定",

--- a/src/i18n/locales/ja/carbon_chatbot.ts
+++ b/src/i18n/locales/ja/carbon_chatbot.ts
@@ -172,6 +172,12 @@ export const carbonChatbot = {
   data_badge_violated: "データセクション：質量保存違反 ⚠（表は凍結中）",
   data_badge_insufficient:
     "データセクション：データ不足（活動データが揃い次第自動生成）",
+  chart_scope_pie_title: "スコープ別排出割合 (kgCO2e)",
+  chart_scope_bar_title: "スコープ別排出量 (kgCO2e)",
+  chart_insufficient:
+    "（データ不足：活動データが揃い次第、システムがグラフを自動生成します）",
+  chart_frozen:
+    "⚠ 質量保存チェックに未合格のため、グラフは凍結されています。チャットで在庫差異を明確にすると自動的に生成されます。",
   inventory_step_ORG_PROFILE: "ステップ:企業基本情報(名称/年度)",
   inventory_step_ORG_BOUNDARY: "ステップ:組織境界の設定",
   inventory_step_EMISSION_SOURCES: "ステップ:排出源の特定",

--- a/src/i18n/locales/ja/carbon_chatbot.ts
+++ b/src/i18n/locales/ja/carbon_chatbot.ts
@@ -152,6 +152,26 @@ export const carbonChatbot = {
     "期首+購入-期末 = {{expected}} {{unit}}、記録上の消費 = {{actual}} {{unit}}、差異 = {{gap}} {{unit}}",
   articulation_plausibility_warning:
     "数量が妥当な範囲を超えています。ご確認ください：{{source}}",
+  report_table_detail_heading: "排出源明細",
+  report_table_col_source: "排出源",
+  report_table_col_scope: "スコープ",
+  report_table_col_quantity: "活動データ",
+  report_table_col_factor: "排出係数（出典）",
+  report_table_col_co2e: "排出量 (kgCO2e)",
+  report_table_subtotal_heading: "スコープ別小計",
+  report_table_total: "総排出量",
+  report_table_insufficient:
+    "（データ不足：活動データが揃い次第、システムが自動的に表を生成します）",
+  report_table_frozen:
+    "⚠ 質量保存チェックに未合格のため、データ表は凍結されています。チャットで在庫差異を明確にすると自動的に生成されます。",
+  report_table_pending_note:
+    "注：{count} 件の活動データは係数待ちのため、本表に含まれていません。",
+  data_table_refreshed:
+    "データ表が活動データに合わせて更新されました。該当セクションを再確認してください",
+  data_badge_reconciled: "データセクション：照合済み ✓（数値は決定論エンジン産出）",
+  data_badge_violated: "データセクション：質量保存違反 ⚠（表は凍結中）",
+  data_badge_insufficient:
+    "データセクション：データ不足（活動データが揃い次第自動生成）",
   inventory_step_ORG_PROFILE: "ステップ:企業基本情報(名称/年度)",
   inventory_step_ORG_BOUNDARY: "ステップ:組織境界の設定",
   inventory_step_EMISSION_SOURCES: "ステップ:排出源の特定",

--- a/src/i18n/locales/ko/carbon_chatbot.ts
+++ b/src/i18n/locales/ko/carbon_chatbot.ts
@@ -151,6 +151,26 @@ export const carbonChatbot = {
     "기초+구매-기말 = {{expected}} {{unit}}, 장부상 소비 = {{actual}} {{unit}}, 차이 = {{gap}} {{unit}}",
   articulation_plausibility_warning:
     "수량이 합리적 범위를 초과했습니다. 확인해 주세요: {{source}}",
+  report_table_detail_heading: "배출원 명세",
+  report_table_col_source: "배출원",
+  report_table_col_scope: "스코프",
+  report_table_col_quantity: "활동 데이터",
+  report_table_col_factor: "배출계수(출처)",
+  report_table_col_co2e: "배출량 (kgCO2e)",
+  report_table_subtotal_heading: "스코프별 소계",
+  report_table_total: "총 배출량",
+  report_table_insufficient:
+    "(데이터 부족: 활동 데이터가 완성되면 시스템이 표를 자동 생성합니다)",
+  report_table_frozen:
+    "⚠ 질량 보존 검증에 통과하지 못해 데이터 표가 동결되었습니다. 대화에서 재고 차이를 해명하면 자동으로 생성됩니다.",
+  report_table_pending_note:
+    "참고: {count}건의 활동 데이터가 계수 대기 중으로 본 표에 포함되지 않았습니다.",
+  data_table_refreshed:
+    "데이터 표가 활동 데이터에 맞춰 갱신되었습니다. 해당 섹션을 다시 확인해 주세요",
+  data_badge_reconciled: "데이터 섹션: 대사 완료 ✓ (수치는 결정론 엔진 산출)",
+  data_badge_violated: "데이터 섹션: 질량 보존 위반 ⚠ (표 동결, 해명 대기)",
+  data_badge_insufficient:
+    "데이터 섹션: 데이터 부족 (활동 데이터 완성 시 자동 생성)",
   inventory_step_ORG_PROFILE: "단계: 기업 기본 정보(명칭/연도)",
   inventory_step_ORG_BOUNDARY: "단계: 조직 경계 설정",
   inventory_step_EMISSION_SOURCES: "단계: 배출원 식별",

--- a/src/i18n/locales/ko/carbon_chatbot.ts
+++ b/src/i18n/locales/ko/carbon_chatbot.ts
@@ -145,6 +145,12 @@ export const carbonChatbot = {
   activity_pending_factor:
     "⚠ 보류: 신뢰할 수 있는 계수가 없거나 단위 불일치로 추정하지 않습니다",
   activity_total_co2e: "총 배출량(대사 완료)",
+  articulation_passed: "질량 보존 검증 통과",
+  articulation_violation: "질량 보존 위반: {{material}}",
+  articulation_equation:
+    "기초+구매-기말 = {{expected}} {{unit}}, 장부상 소비 = {{actual}} {{unit}}, 차이 = {{gap}} {{unit}}",
+  articulation_plausibility_warning:
+    "수량이 합리적 범위를 초과했습니다. 확인해 주세요: {{source}}",
   inventory_step_ORG_PROFILE: "단계: 기업 기본 정보(명칭/연도)",
   inventory_step_ORG_BOUNDARY: "단계: 조직 경계 설정",
   inventory_step_EMISSION_SOURCES: "단계: 배출원 식별",

--- a/src/i18n/locales/ko/carbon_chatbot.ts
+++ b/src/i18n/locales/ko/carbon_chatbot.ts
@@ -171,6 +171,12 @@ export const carbonChatbot = {
   data_badge_violated: "데이터 섹션: 질량 보존 위반 ⚠ (표 동결, 해명 대기)",
   data_badge_insufficient:
     "데이터 섹션: 데이터 부족 (활동 데이터 완성 시 자동 생성)",
+  chart_scope_pie_title: "스코프별 배출 비중 (kgCO2e)",
+  chart_scope_bar_title: "스코프별 배출량 (kgCO2e)",
+  chart_insufficient:
+    "(데이터 부족: 활동 데이터가 완성되면 시스템이 차트를 자동 생성합니다)",
+  chart_frozen:
+    "⚠ 질량 보존 검증에 통과하지 못해 차트가 동결되었습니다. 대화에서 재고 차이를 해명하면 자동으로 생성됩니다.",
   inventory_step_ORG_PROFILE: "단계: 기업 기본 정보(명칭/연도)",
   inventory_step_ORG_BOUNDARY: "단계: 조직 경계 설정",
   inventory_step_EMISSION_SOURCES: "단계: 배출원 식별",

--- a/src/i18n/locales/zh_cn/carbon_chatbot.ts
+++ b/src/i18n/locales/zh_cn/carbon_chatbot.ts
@@ -152,6 +152,11 @@ export const carbonChatbot = {
   data_badge_reconciled: "数据段落：已核对 ✓（数字由确定性引擎产出）",
   data_badge_violated: "数据段落：质量守恒违反 ⚠（表格已冻结，待澄清）",
   data_badge_insufficient: "数据段落：数据不足（补齐活动数据后自动生成）",
+  chart_scope_pie_title: "各范畴排放占比 (kgCO2e)",
+  chart_scope_bar_title: "各范畴排放量 (kgCO2e)",
+  chart_insufficient: "（数据不足，补齐活动数据后由系统自动生成图表）",
+  chart_frozen:
+    "⚠ 质量守恒核对未通过，图表已冻结。请于对话中澄清库存缺口后，图表将自动生成。",
   inventory_step_ORG_PROFILE: "步骤: 企业基本资料（名称／年度）",
   inventory_step_ORG_BOUNDARY: "步骤: 组织边界设定",
   inventory_step_EMISSION_SOURCES: "步骤: 排放源识别",

--- a/src/i18n/locales/zh_cn/carbon_chatbot.ts
+++ b/src/i18n/locales/zh_cn/carbon_chatbot.ts
@@ -130,6 +130,11 @@ export const carbonChatbot = {
   activity_co2e: "CO2e: {{value}} kg",
   activity_pending_factor: "⚠ 待补: 查无可靠系数或单位不符,不予推估",
   activity_total_co2e: "总排放量（已核对）",
+  articulation_passed: "质量守恒核对通过",
+  articulation_violation: "质量守恒违反：{{material}}",
+  articulation_equation:
+    "期初+采购-期末 = {{expected}} {{unit}}，账上消耗 = {{actual}} {{unit}}，缺口 = {{gap}} {{unit}}",
+  articulation_plausibility_warning: "数量超出合理量级，请确认：{{source}}",
   inventory_step_ORG_PROFILE: "步骤: 企业基本资料（名称／年度）",
   inventory_step_ORG_BOUNDARY: "步骤: 组织边界设定",
   inventory_step_EMISSION_SOURCES: "步骤: 排放源识别",

--- a/src/i18n/locales/zh_cn/carbon_chatbot.ts
+++ b/src/i18n/locales/zh_cn/carbon_chatbot.ts
@@ -135,6 +135,23 @@ export const carbonChatbot = {
   articulation_equation:
     "期初+采购-期末 = {{expected}} {{unit}}，账上消耗 = {{actual}} {{unit}}，缺口 = {{gap}} {{unit}}",
   articulation_plausibility_warning: "数量超出合理量级，请确认：{{source}}",
+  report_table_detail_heading: "排放源明细",
+  report_table_col_source: "排放源",
+  report_table_col_scope: "范畴",
+  report_table_col_quantity: "活动数据",
+  report_table_col_factor: "排放系数（来源）",
+  report_table_col_co2e: "排放量 (kgCO2e)",
+  report_table_subtotal_heading: "范畴小计",
+  report_table_total: "总排放量",
+  report_table_insufficient:
+    "（数据不足，补齐活动数据后由系统自动生成数据表格）",
+  report_table_frozen:
+    "⚠ 质量守恒核对未通过，数据表格已冻结。请于对话中澄清库存缺口后，表格将自动生成。",
+  report_table_pending_note: "注：尚有 {count} 笔活动数据待补系数，未计入下表。",
+  data_table_refreshed: "数据表格已随活动数据更新，请重新核对相关段落",
+  data_badge_reconciled: "数据段落：已核对 ✓（数字由确定性引擎产出）",
+  data_badge_violated: "数据段落：质量守恒违反 ⚠（表格已冻结，待澄清）",
+  data_badge_insufficient: "数据段落：数据不足（补齐活动数据后自动生成）",
   inventory_step_ORG_PROFILE: "步骤: 企业基本资料（名称／年度）",
   inventory_step_ORG_BOUNDARY: "步骤: 组织边界设定",
   inventory_step_EMISSION_SOURCES: "步骤: 排放源识别",

--- a/src/i18n/locales/zh_tw/carbon_chatbot.ts
+++ b/src/i18n/locales/zh_tw/carbon_chatbot.ts
@@ -135,6 +135,23 @@ export const carbonChatbot = {
   articulation_equation:
     "期初+採購-期末 = {{expected}} {{unit}}，帳上消耗 = {{actual}} {{unit}}，缺口 = {{gap}} {{unit}}",
   articulation_plausibility_warning: "數量超出合理量級，請確認：{{source}}",
+  report_table_detail_heading: "排放源明細",
+  report_table_col_source: "排放源",
+  report_table_col_scope: "範疇",
+  report_table_col_quantity: "活動數據",
+  report_table_col_factor: "排放係數（來源）",
+  report_table_col_co2e: "排放量 (kgCO2e)",
+  report_table_subtotal_heading: "範疇小計",
+  report_table_total: "總排放量",
+  report_table_insufficient:
+    "（資料不足，補齊活動數據後由系統自動生成數據表格）",
+  report_table_frozen:
+    "⚠ 質量守恆勾稽未通過，數據表格已凍結。請於對話中澄清庫存缺口後，表格將自動生成。",
+  report_table_pending_note: "註：尚有 {count} 筆活動數據待補係數，未計入下表。",
+  data_table_refreshed: "數據表格已隨活動數據更新，請重新查核相關段落",
+  data_badge_reconciled: "數據段落：已勾稽 ✓（數字由決定論引擎產出）",
+  data_badge_violated: "數據段落：質量守恆違反 ⚠（表格已凍結，待澄清）",
+  data_badge_insufficient: "數據段落：數據不足（補齊活動數據後自動生成）",
   inventory_step_ORG_PROFILE: "步驟: 企業基本資料（名稱／年度）",
   inventory_step_ORG_BOUNDARY: "步驟: 組織邊界設定",
   inventory_step_EMISSION_SOURCES: "步驟: 排放源鑑別",

--- a/src/i18n/locales/zh_tw/carbon_chatbot.ts
+++ b/src/i18n/locales/zh_tw/carbon_chatbot.ts
@@ -130,6 +130,11 @@ export const carbonChatbot = {
   activity_co2e: "CO2e: {{value}} kg",
   activity_pending_factor: "⚠ 待補: 查無可靠係數或單位不符,不予推估",
   activity_total_co2e: "總排放量（已勾稽）",
+  articulation_passed: "質量守恆勾稽通過",
+  articulation_violation: "質量守恆違反：{{material}}",
+  articulation_equation:
+    "期初+採購-期末 = {{expected}} {{unit}}，帳上消耗 = {{actual}} {{unit}}，缺口 = {{gap}} {{unit}}",
+  articulation_plausibility_warning: "數量超出合理量級，請確認：{{source}}",
   inventory_step_ORG_PROFILE: "步驟: 企業基本資料（名稱／年度）",
   inventory_step_ORG_BOUNDARY: "步驟: 組織邊界設定",
   inventory_step_EMISSION_SOURCES: "步驟: 排放源鑑別",

--- a/src/i18n/locales/zh_tw/carbon_chatbot.ts
+++ b/src/i18n/locales/zh_tw/carbon_chatbot.ts
@@ -152,6 +152,11 @@ export const carbonChatbot = {
   data_badge_reconciled: "數據段落：已勾稽 ✓（數字由決定論引擎產出）",
   data_badge_violated: "數據段落：質量守恆違反 ⚠（表格已凍結，待澄清）",
   data_badge_insufficient: "數據段落：數據不足（補齊活動數據後自動生成）",
+  chart_scope_pie_title: "各範疇排放占比 (kgCO2e)",
+  chart_scope_bar_title: "各範疇排放量 (kgCO2e)",
+  chart_insufficient: "（資料不足，補齊活動數據後由系統自動生成圖表）",
+  chart_frozen:
+    "⚠ 質量守恆勾稽未通過，圖表已凍結。請於對話中澄清庫存缺口後，圖表將自動生成。",
   inventory_step_ORG_PROFILE: "步驟: 企業基本資料（名稱／年度）",
   inventory_step_ORG_BOUNDARY: "步驟: 組織邊界設定",
   inventory_step_EMISSION_SOURCES: "步驟: 排放源鑑別",

--- a/src/lib/carbon_inventory.ts
+++ b/src/lib/carbon_inventory.ts
@@ -6,12 +6,14 @@ import {
   IActivityRecord,
   IInventoryExtraction,
   IComputedLedger,
+  IMaterialStockRecord,
 } from "@/types/carbon_chatbot.types";
 import {
   CarbonInventoryStep,
   CARBON_INVENTORY_STEP_ORDER,
   CARBON_INVENTORY_STATE_VERSION,
 } from "@/constants/carbon_chatbot";
+import { ArticulationStatusEnum } from "@/constants/carbon_articulation";
 
 // Info: (20260716 - Emily) ACTIVITY_DATA 完成門檻: 至少 N 筆完整活動數據(門檻為決定性常數，不由 LLM 判斷)
 export const CARBON_INVENTORY_MIN_ACTIVITY_RECORDS = 3;
@@ -32,6 +34,10 @@ export const activityDedupeKey = (a: IActivityRecord): string =>
     a.quantity.trim(),
     a.unit,
   ].join("|");
+
+// Info: (20260720 - Emily) #6520 庫存紀錄去重鍵:同物料 + 同單位視為同一筆(後到的萃取不覆蓋人工確認值)
+export const stockRecordDedupeKey = (r: IMaterialStockRecord): string =>
+  [r.materialName.trim().toLowerCase(), r.unit].join("|");
 
 export interface IMergeResult {
   state: ICarbonInventoryState;
@@ -62,16 +68,36 @@ export const mergeInventoryExtraction = (
     added.push(record);
   });
 
+  // Info: (20260720 - Emily) #6520 庫存紀錄同軌合併(去重鍵:物料+單位;重送不重複記帳)
+  const existingStockKeys = new Set(
+    (state.stockRecords ?? []).map(stockRecordDedupeKey),
+  );
+  const addedStock: IMaterialStockRecord[] = [];
+  (extraction.stockRecords ?? []).forEach((record) => {
+    const withSource: IMaterialStockRecord = {
+      ...record,
+      source: record.source ?? source,
+    };
+    const key = stockRecordDedupeKey(withSource);
+    if (existingStockKeys.has(key)) return;
+    existingStockKeys.add(key);
+    addedStock.push(withSource);
+  });
+
   const next: ICarbonInventoryState = {
     ...state,
     company: state.company ?? extraction.company,
     year: state.year ?? extraction.year,
     boundaryApproach: state.boundaryApproach ?? extraction.boundaryApproach,
     activities: [...state.activities, ...added],
+    stockRecords:
+      addedStock.length > 0
+        ? [...(state.stockRecords ?? []), ...addedStock]
+        : state.stockRecords,
     updatedAt: new Date().toISOString(),
   };
   next.step = computeInventoryStep(next);
-  return { state: next, addedCount: added.length };
+  return { state: next, addedCount: added.length + addedStock.length };
 };
 
 // Info: (20260716 - Emily) 各步驟完成條件(決定性；EMISSION_FACTORS/REVIEW 的出口由 #21/#22 引擎解鎖)
@@ -98,8 +124,15 @@ const isStepComplete = (
         state.activities.every((a) => Boolean(a.emissionFactor))
       );
     case CarbonInventoryStep.REVIEW:
-      // Info: (20260716 - Emily) 勾稽通過才算完成；由 #6520(質量守恆護欄)裁決
-      return false;
+      // Info: (20260720 - Emily) #6520 勾稽出口:計算總表存在、無待補、守恆非違反(NOT_APPLICABLE =
+      // Info: (20260720 - Emily) 純電力/運輸盤查的合法情境,視為通過;VIOLATED 凍結直到使用者澄清)
+      return Boolean(
+        state.computedLedger &&
+          state.computedLedger.pending.length === 0 &&
+          state.computedLedger.articulation &&
+          state.computedLedger.articulation.status !==
+            ArticulationStatusEnum.VIOLATED,
+      );
     default:
       return false;
   }
@@ -117,6 +150,7 @@ export const computeInventoryStep = (
 };
 
 // Info: (20260716 - Emily) 供 persona 的步驟描述(餵給 LLM 的 currentStep 真值，取代自由字串)
+// Info: (20260720 - Emily) #6520 守恆違反時附上等式事實(TS 決定性產生;LLM 只負責措辭向使用者追問澄清)
 export const describeInventoryStep = (state: ICarbonInventoryState): string => {
   const missing: string[] = [];
   if (!state.company) missing.push("企業名稱");
@@ -125,7 +159,18 @@ export const describeInventoryStep = (state: ICarbonInventoryState): string => {
   const activityGap =
     CARBON_INVENTORY_MIN_ACTIVITY_RECORDS - state.activities.length;
   if (activityGap > 0) missing.push(`活動數據(尚缺約 ${activityGap} 筆)`);
-  return `${state.step}${missing.length > 0 ? `；待蒐集: ${missing.join("、")}` : ""}`;
+
+  const violations = state.computedLedger?.articulation?.violations ?? [];
+  const violationBlock =
+    violations.length > 0
+      ? `；【質量守恆勾稽違反,請以會計師身份向用戶追問缺口原因,嚴禁自行推測數字】${violations
+          .map(
+            (v) =>
+              `${v.materialName}: 期初+採購-期末=${v.expectedConsumption} ${v.unit},帳上消耗=${v.actualConsumption} ${v.unit},缺口=${v.gap} ${v.unit}`,
+          )
+          .join("；")}`
+      : "";
+  return `${state.step}${missing.length > 0 ? `；待蒐集: ${missing.join("、")}` : ""}${violationBlock}`;
 };
 
 /**

--- a/src/lib/carbon_quantity.ts
+++ b/src/lib/carbon_quantity.ts
@@ -1,0 +1,17 @@
+// Info: (20260720 - Emily) 數量字串決定性解析(純函式,零依賴):
+// Info: (20260720 - Emily) 自 carbon_calculation.service 抽出 — 該服務經 EmissionFactorRepo 連動真實
+// Info: (20260720 - Emily) prisma(pg Pool),守恆勾稽(#6520)等純邏輯呼叫端若 import 它,單元測試會
+// Info: (20260720 - Emily) 連帶開啟 DB 連線造成 jest worker 無法退出;純函式歸 lib,服務歸服務
+
+/**
+ * Info: (20260716 - Emily) 全形轉半形、去千分位/空白;
+ * 合法格式僅「非負十進位數」;其餘(科學記號/負數/文字)回 null → 待補,絕不猜。
+ */
+export const parseActivityQuantity = (raw: string): string | null => {
+  const halfWidth = raw.replace(/[０-９．]/g, (ch) =>
+    ch === "．" ? "." : String.fromCharCode(ch.charCodeAt(0) - 0xfee0),
+  );
+  const cleaned = halfWidth.replace(/[,\s，]/g, "");
+  if (!/^\d+(\.\d+)?$/.test(cleaned)) return null;
+  return cleaned;
+};

--- a/src/lib/carbon_report_chart.builder.ts
+++ b/src/lib/carbon_report_chart.builder.ts
@@ -1,0 +1,154 @@
+// Info: (20260720 - Emily) 報告圖表產生器(#51):模板 × computedLedger → mermaid/markdown 字串
+// Info: (20260720 - Emily) 決定性純函式(同輸入同輸出);數值取引擎原始 Decimal 字串(mermaid 自行解析,
+// Info: (20260720 - Emily) 不加千分位以免圖表引擎誤讀);LLM 夾帶的自繪圖表不經本模組即不合法
+// Info: (20260720 - Emily) 語法沿用 Julian 的 markdown 渲染鏈(mermaid pie / xychart-beta),
+// Info: (20260720 - Emily) 與 /admin/pdf_tool 寫法一致,下載 PDF 即含圖
+// Info: (20260720 - Emily) 防護:空 ledger → 佔位不畫空圖;守恆違反(#22)→ 凍結告警(比照 #23 表格)
+
+import { MoneyUtil } from "@/lib/utils/money";
+import { ArticulationStatusEnum } from "@/constants/carbon_articulation";
+import {
+  CarbonChartTemplateEnum,
+  buildChartAnchorStart,
+  buildChartAnchorEnd,
+  CARBON_CHART_ANCHOR_PREFIX,
+} from "@/constants/carbon_report_charts";
+import {
+  buildCarbonDataTable,
+  ICarbonDataTableLabels,
+  CARBON_DATA_TABLE_DEFAULT_LABELS,
+} from "@/lib/carbon_report_table.builder";
+import { IComputedLedger } from "@/types/carbon_chatbot.types";
+
+// Info: (20260720 - Emily) 圖表文案(由呼叫端以 i18n 注入;佔位/凍結沿用 #23 表格文案語意)
+export interface ICarbonChartLabels {
+  pieTitle: string;
+  barTitle: string;
+  axisCo2e: string;
+  insufficient: string;
+  frozen: string;
+}
+
+export const CARBON_CHART_DEFAULT_LABELS: ICarbonChartLabels = {
+  pieTitle: "各範疇排放占比 (kgCO2e)",
+  barTitle: "各範疇排放量 (kgCO2e)",
+  axisCo2e: "kgCO2e",
+  insufficient: "(資料不足,補齊活動數據後由系統自動生成圖表)",
+  frozen:
+    "⚠ 質量守恆勾稽未通過,圖表已凍結。請於對話中澄清庫存缺口後,圖表將自動生成。",
+};
+
+// Info: (20260720 - Emily) mermaid 數值:引擎 Decimal 字串正規化(去千分位疑慮,不經 number)
+const chartValue = (value: string): string =>
+  MoneyUtil.toDecimal(value).toString();
+
+const buildScopePie = (
+  ledger: IComputedLedger,
+  labels: ICarbonChartLabels,
+): string => {
+  const rows = Object.entries(ledger.scopeSubtotals)
+    .map(([scope, subtotal]) => `    "${scope}" : ${chartValue(subtotal)}`)
+    .join("\n");
+  return `\`\`\`mermaid\npie title ${labels.pieTitle}\n${rows}\n\`\`\``;
+};
+
+const buildScopeBar = (
+  ledger: IComputedLedger,
+  labels: ICarbonChartLabels,
+): string => {
+  const scopes = Object.keys(ledger.scopeSubtotals);
+  const values = Object.values(ledger.scopeSubtotals).map(chartValue);
+  return [
+    "```mermaid",
+    "xychart-beta",
+    `    title "${labels.barTitle}"`,
+    `    x-axis [${scopes.map((s) => `"${s}"`).join(", ")}]`,
+    `    y-axis "${labels.axisCo2e}"`,
+    `    bar [${values.join(", ")}]`,
+    "```",
+  ].join("\n");
+};
+
+/**
+ * Info: (20260720 - Emily) 產出模板圖表區塊(錨點包夾,供重算連動替換):
+ * 守恆違反 → 凍結告警;空 ledger → 佔位;數值一律引擎產出
+ */
+export const buildCarbonChartBlock = (
+  templateId: CarbonChartTemplateEnum,
+  ledger: IComputedLedger | undefined,
+  labels: ICarbonChartLabels = CARBON_CHART_DEFAULT_LABELS,
+  tableLabels: ICarbonDataTableLabels = CARBON_DATA_TABLE_DEFAULT_LABELS,
+): string => {
+  const wrap = (body: string): string =>
+    `${buildChartAnchorStart(templateId)}\n\n${body}\n\n${buildChartAnchorEnd(templateId)}`;
+
+  if (ledger?.articulation?.status === ArticulationStatusEnum.VIOLATED) {
+    return wrap(`> ${labels.frozen}`);
+  }
+  if (!ledger || ledger.entries.length === 0) {
+    return wrap(`> _${labels.insufficient}_`);
+  }
+
+  switch (templateId) {
+    case CarbonChartTemplateEnum.SCOPE_PIE:
+      return wrap(buildScopePie(ledger, labels));
+    case CarbonChartTemplateEnum.SCOPE_BAR:
+      return wrap(buildScopeBar(ledger, labels));
+    case CarbonChartTemplateEnum.SOURCE_TABLE:
+    default:
+      // Info: (20260720 - Emily) 明細表復用 #23 產生器(去其外層錨點,改包本模板錨點避免雙重替換)
+      return wrap(
+        buildCarbonDataTable(ledger, tableLabels)
+          .split("\n")
+          .filter((line) => !line.startsWith("<!-- carbon-data-table"))
+          .join("\n")
+          .trim(),
+      );
+  }
+};
+
+/**
+ * Info: (20260720 - Emily) 插入圖表至段落內容:同模板錨點已存在 → 原地替換(不疊加);否則附加於尾端
+ */
+export const insertCarbonChartBlock = (
+  content: string,
+  templateId: CarbonChartTemplateEnum,
+  block: string,
+): string => {
+  const start = buildChartAnchorStart(templateId);
+  const end = buildChartAnchorEnd(templateId);
+  const startIndex = content.indexOf(start);
+  const endIndex = content.indexOf(end);
+  if (startIndex !== -1 && endIndex !== -1 && endIndex > startIndex) {
+    const before = content.slice(0, startIndex).replace(/\s+$/, "");
+    const after = content.slice(endIndex + end.length).replace(/^\s+/, "");
+    return [before, block, after].filter(Boolean).join("\n\n");
+  }
+  const trimmed = content.trim();
+  return trimmed ? `${trimmed}\n\n${block}` : block;
+};
+
+// Info: (20260720 - Emily) 內容是否含任何模板圖表(重算連動的掃描條件)
+export const hasCarbonChartBlocks = (content: string): boolean =>
+  content.includes(`<!-- ${CARBON_CHART_ANCHOR_PREFIX}:`);
+
+/**
+ * Info: (20260720 - Emily) 重算連動:重建內容中所有已插入的模板圖表(白名單逐一檢查,敘述零改動)
+ */
+export const refreshCarbonChartBlocks = (
+  content: string,
+  ledger: IComputedLedger | undefined,
+  labels: ICarbonChartLabels = CARBON_CHART_DEFAULT_LABELS,
+  tableLabels: ICarbonDataTableLabels = CARBON_DATA_TABLE_DEFAULT_LABELS,
+): string => {
+  let next = content;
+  Object.values(CarbonChartTemplateEnum).forEach((templateId) => {
+    if (!next.includes(buildChartAnchorStart(templateId))) return;
+    next = insertCarbonChartBlock(
+      next,
+      templateId,
+      buildCarbonChartBlock(templateId, ledger, labels, tableLabels),
+    );
+  });
+  return next;
+};

--- a/src/lib/carbon_report_table.builder.ts
+++ b/src/lib/carbon_report_table.builder.ts
@@ -1,0 +1,158 @@
+// Info: (20260720 - Emily) 報告數據表格產生器(#23):數據段落的表格由本模組從 computedLedger 決定性產出
+// Info: (20260720 - Emily) 廢除空殼 categories 佔位 —「數據段落:數字由系統勾稽計算」徽章自此為真實聲明
+// Info: (20260720 - Emily) 鐵律:數字一律來自決定論引擎(字串化 Decimal),LLM 零參與填值;
+// Info: (20260720 - Emily) LLM 草稿夾帶的任何表格由 stripLlmTables 丟棄(zero fabrication 執行面)
+// Info: (20260720 - Emily) 守恆違反(#22)→ 拒產表格,以醒目告警取代(審計軌跡:PDF 匯出保留,不得美化)
+
+import { MoneyUtil } from "@/lib/utils/money";
+import { ArticulationStatusEnum } from "@/constants/carbon_articulation";
+import { IComputedLedger } from "@/types/carbon_chatbot.types";
+
+// Info: (20260720 - Emily) 表格注入錨點(HTML 註解:Markdown 渲染不可見、PDF 不輸出;重算時依此替換不動敘述)
+export const CARBON_DATA_TABLE_START = "<!-- carbon-data-table:start -->";
+export const CARBON_DATA_TABLE_END = "<!-- carbon-data-table:end -->";
+
+// Info: (20260720 - Emily) 數據段落勾稽徽章三態(目錄樹顯示;違反時段落內另有告警)
+export enum CarbonDataBadgeStateEnum {
+  RECONCILED = "RECONCILED",
+  VIOLATED = "VIOLATED",
+  INSUFFICIENT = "INSUFFICIENT",
+}
+
+// Info: (20260720 - Emily) 表格文案(由呼叫端以 i18n 注入;預設 zh-TW,與既有報告組稿語言慣例一致)
+export interface ICarbonDataTableLabels {
+  detailHeading: string;
+  colSource: string;
+  colScope: string;
+  colQuantity: string;
+  colFactor: string;
+  colCo2e: string;
+  subtotalHeading: string;
+  total: string;
+  insufficient: string;
+  frozen: string;
+  pendingNote: string;
+}
+
+export const CARBON_DATA_TABLE_DEFAULT_LABELS: ICarbonDataTableLabels = {
+  detailHeading: "排放源明細",
+  colSource: "排放源",
+  colScope: "範疇",
+  colQuantity: "活動數據",
+  colFactor: "排放係數(來源)",
+  colCo2e: "排放量 (kgCO2e)",
+  subtotalHeading: "範疇小計",
+  total: "總排放量",
+  insufficient: "(資料不足,補齊活動數據後由系統自動生成數據表格)",
+  frozen:
+    "⚠ 質量守恆勾稽未通過,數據表格已凍結。請於對話中澄清庫存缺口後,表格將自動生成。",
+  pendingNote: "註:尚有 {count} 筆活動數據待補係數,未計入下表。",
+};
+
+// Info: (20260720 - Emily) 徽章三態裁決(決定性):違反 > 有數據 > 不足
+export const deriveDataBadgeState = (
+  ledger: IComputedLedger | undefined,
+): CarbonDataBadgeStateEnum => {
+  if (
+    ledger?.articulation?.status === ArticulationStatusEnum.VIOLATED
+  ) {
+    return CarbonDataBadgeStateEnum.VIOLATED;
+  }
+  if (ledger && ledger.entries.length > 0) {
+    return CarbonDataBadgeStateEnum.RECONCILED;
+  }
+  return CarbonDataBadgeStateEnum.INSUFFICIENT;
+};
+
+/**
+ * Info: (20260720 - Emily) 從計算總表決定性產出 markdown 表格區塊(含錨點包夾):
+ * - 違反守恆 → 告警取代表格(凍結;PDF 保留)
+ * - 無資料 → 佔位說明(不畫空表)
+ * - 數字格式化走 MoneyUtil.formatDynamic(Decimal 千分位,無 number 運算)
+ */
+export const buildCarbonDataTable = (
+  ledger: IComputedLedger | undefined,
+  labels: ICarbonDataTableLabels = CARBON_DATA_TABLE_DEFAULT_LABELS,
+): string => {
+  const wrap = (body: string): string =>
+    `${CARBON_DATA_TABLE_START}\n\n${body}\n\n${CARBON_DATA_TABLE_END}`;
+
+  if (ledger?.articulation?.status === ArticulationStatusEnum.VIOLATED) {
+    return wrap(`> ${labels.frozen}`);
+  }
+  if (!ledger || ledger.entries.length === 0) {
+    return wrap(`> _${labels.insufficient}_`);
+  }
+
+  const lines: string[] = [];
+  lines.push(`**${labels.detailHeading}**`);
+  lines.push("");
+  lines.push(
+    `| ${labels.colSource} | ${labels.colScope} | ${labels.colQuantity} | ${labels.colFactor} | ${labels.colCo2e} |`,
+  );
+  lines.push("| --- | --- | --- | --- | ---: |");
+  ledger.entries.forEach((entry) => {
+    lines.push(
+      `| ${entry.sourceName} | ${entry.scopeCategory} | ${MoneyUtil.formatDynamic(entry.convertedQuantity, 3)} ${entry.convertedUnit} | ${entry.factor.value}(${entry.factor.source}) | ${MoneyUtil.formatDynamic(entry.co2eKg, 3)} |`,
+    );
+  });
+
+  lines.push("");
+  lines.push(`**${labels.subtotalHeading}**`);
+  lines.push("");
+  lines.push(`| ${labels.colScope} | ${labels.colCo2e} |`);
+  lines.push("| --- | ---: |");
+  Object.entries(ledger.scopeSubtotals).forEach(([scope, subtotal]) => {
+    lines.push(`| ${scope} | ${MoneyUtil.formatDynamic(subtotal, 3)} |`);
+  });
+  lines.push(
+    `| **${labels.total}** | **${MoneyUtil.formatDynamic(ledger.totalCo2eKg, 3)}** |`,
+  );
+
+  if (ledger.pending.length > 0) {
+    lines.push("");
+    lines.push(
+      `> _${labels.pendingNote.replace("{count}", String(ledger.pending.length))}_`,
+    );
+  }
+  return wrap(lines.join("\n"));
+};
+
+/**
+ * Info: (20260720 - Emily) 丟棄 LLM 草稿夾帶的 markdown 表格(fence-aware):
+ * 數據段落的表格唯一合法來源是本模組;LLM 敘述中的 |...| 表格列(含分隔列)整塊移除
+ */
+export const stripLlmTables = (content: string): string => {
+  const lines = content.split("\n");
+  const kept: string[] = [];
+  let inFence = false;
+  lines.forEach((line) => {
+    if (/^\s*(```|~~~)/.test(line)) inFence = !inFence;
+    if (!inFence && /^\s*\|.*\|\s*$/.test(line)) return;
+    kept.push(line);
+  });
+  // Info: (20260720 - Emily) 移除表格後可能留下連續空行,收斂為單一空行
+  return kept.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+};
+
+/**
+ * Info: (20260720 - Emily) 表格注入/替換(重算連動的核心):
+ * 內容已含錨點 → 只替換錨點區塊(敘述零改動);無錨點 → 附加於內容尾端
+ */
+export const injectDataTable = (content: string, tableBlock: string): string => {
+  const startIndex = content.indexOf(CARBON_DATA_TABLE_START);
+  const endIndex = content.indexOf(CARBON_DATA_TABLE_END);
+  if (startIndex !== -1 && endIndex !== -1 && endIndex > startIndex) {
+    const before = content.slice(0, startIndex).replace(/\s+$/, "");
+    const after = content
+      .slice(endIndex + CARBON_DATA_TABLE_END.length)
+      .replace(/^\s+/, "");
+    return [before, tableBlock, after].filter(Boolean).join("\n\n");
+  }
+  const trimmed = content.trim();
+  return trimmed ? `${trimmed}\n\n${tableBlock}` : tableBlock;
+};
+
+// Info: (20260720 - Emily) 內容是否已含注入表格(重算連動的掃描條件)
+export const hasInjectedDataTable = (content: string): boolean =>
+  content.includes(CARBON_DATA_TABLE_START);

--- a/src/lib/utils/error_dictionary.ts
+++ b/src/lib/utils/error_dictionary.ts
@@ -737,6 +737,12 @@ export const API_ERRORS = {
     message: "Failed to import the report",
     status: ApiCode.INTERNAL_SERVER_ERROR,
   } as IErrorDef,
+  // Info: (20260720 - Emily) #6520 質量守恆勾稽違反:報告數據段落凍結,待使用者澄清缺口(防漂綠護欄)
+  IS_MASS_CONSERVATION_VIOLATED: {
+    code: "IS000018",
+    message: "Mass conservation check failed; data sections are frozen",
+    status: ApiCode.VALIDATION_ERROR,
+  } as IErrorDef,
   IS_UNKNOWN: {
     code: "IS000099",
     message: "Internal Server Error",

--- a/src/services/carbon_articulation.service.ts
+++ b/src/services/carbon_articulation.service.ts
@@ -1,0 +1,191 @@
+// Info: (20260720 - Emily) 質量守恆勾稽護欄(#6520 / issue 22):純決定性檢核,無 LLM、無 DB、無狀態
+// Info: (20260720 - Emily) 等式:期初庫存 + 本期採購 = 本期投入(消耗) + 期末庫存(± LOSS_RATIO_TOLERANCE)
+// Info: (20260720 - Emily) 哲學:violation 不擋資料入帳(資料仍是事實),但凍結報告數據段落並讓費思追問;
+// Info: (20260720 - Emily) 非庫存類(電力/運輸)改跑合理性區間,超界僅警示(可能是集團級數據,不武斷凍結)
+// Info: (20260720 - Emily) 全程 Decimal 字串經 MoneyUtil,不經 number 中轉(ADR 003)
+
+import { MoneyUtil } from "@/lib/utils/money";
+import { UnitConverter } from "@/lib/utils/unit_converter";
+import { MeasurementUnit } from "@/constants/enums";
+import {
+  LOSS_RATIO_TOLERANCE,
+  STOCKABLE_UNITS,
+  PLAUSIBILITY_MAX_BY_UNIT,
+  ArticulationStatusEnum,
+  ArticulationViolationReasonEnum,
+  ArticulationWarningReasonEnum,
+} from "@/constants/carbon_articulation";
+import { parseActivityQuantity } from "@/services/carbon_calculation.service";
+import { activityDedupeKey } from "@/lib/carbon_inventory";
+import {
+  IActivityRecord,
+  IMaterialStockRecord,
+  IArticulationResult,
+  IArticulationViolation,
+  IArticulationWarning,
+} from "@/types/carbon_chatbot.types";
+
+// Info: (20260720 - Emily) 物料名稱決定性正規化:去空白 + 小寫(庫存紀錄 ↔ 活動數據的對齊鍵)
+export const normalizeMaterialName = (name: string): string =>
+  name.trim().toLowerCase();
+
+// Info: (20260720 - Emily) 單位是否屬可盤點物料(質量/體積)
+export const isStockableUnit = (unit: string): boolean =>
+  (STOCKABLE_UNITS as string[]).includes(unit);
+
+export class CarbonArticulationService {
+  /**
+   * Info: (20260720 - Emily) 全量勾稽(冪等:同輸入同輸出):
+   * 1. 每筆庫存紀錄執行守恆等式檢核(消耗側 = 同名活動數據加總,單位經 UnitConverter 對齊)
+   * 2. 非庫存類活動跑合理性區間(警示不凍結)
+   * 任一數值無法決定性解析/對齊 → violation(無法驗證即不可放行,Fail Fast)
+   */
+  check(
+    activities: IActivityRecord[],
+    stockRecords: IMaterialStockRecord[],
+  ): IArticulationResult {
+    const violations: IArticulationViolation[] = [];
+    stockRecords.forEach((record) => {
+      const violation = this.checkConservation(record, activities);
+      if (violation) violations.push(violation);
+    });
+
+    const warnings = this.checkPlausibility(activities);
+
+    let status: ArticulationStatusEnum;
+    if (violations.length > 0) {
+      status = ArticulationStatusEnum.VIOLATED;
+    } else if (stockRecords.length === 0) {
+      // Info: (20260720 - Emily) 純電力/運輸盤查無庫存紀錄屬合法情境:不適用而非未通過
+      status = ArticulationStatusEnum.NOT_APPLICABLE;
+    } else {
+      status = ArticulationStatusEnum.PASSED;
+    }
+
+    return {
+      status,
+      violations,
+      warnings,
+      checkedAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Info: (20260720 - Emily) 單筆守恆檢核。回傳 null = 通過(含容差內損耗);非 null = violation。
+   * 預期消耗 = 期初 + 採購 - 期末;實際消耗 = 正規化同名活動數據換算至庫存單位後加總。
+   */
+  private checkConservation(
+    record: IMaterialStockRecord,
+    activities: IActivityRecord[],
+  ): IArticulationViolation | null {
+    const base: Pick<IArticulationViolation, "materialName" | "unit"> = {
+      materialName: record.materialName,
+      unit: record.unit,
+    };
+
+    const opening = parseActivityQuantity(record.openingQuantity);
+    const purchased = parseActivityQuantity(record.purchasedQuantity);
+    const closing = parseActivityQuantity(record.closingQuantity);
+    if (!opening || !purchased || !closing) {
+      return {
+        ...base,
+        reason: ArticulationViolationReasonEnum.UNPARSABLE_QUANTITY,
+        expectedConsumption: "0",
+        actualConsumption: "0",
+        gap: "0",
+      };
+    }
+
+    // Info: (20260720 - Emily) 期末 > 期初+採購 → 庫存無中生有,物理不可能,直接凍結
+    const expected = MoneyUtil.subtract(MoneyUtil.add(opening, purchased), closing);
+    if (MoneyUtil.isNegative(expected)) {
+      return {
+        ...base,
+        reason: ArticulationViolationReasonEnum.NEGATIVE_EXPECTED_CONSUMPTION,
+        expectedConsumption: expected,
+        actualConsumption: "0",
+        gap: MoneyUtil.abs(expected),
+      };
+    }
+
+    // Info: (20260720 - Emily) 消耗側加總:同名活動(正規化比對)換算至庫存單位;跨量綱 = 無法驗證 → 凍結
+    const targetName = normalizeMaterialName(record.materialName);
+    const matched = activities.filter(
+      (a) => normalizeMaterialName(a.sourceName) === targetName,
+    );
+    let actual = "0";
+    for (const activity of matched) {
+      const parsed = parseActivityQuantity(activity.quantity);
+      if (!parsed) {
+        // Info: (20260720 - Emily) 消耗數值無法解析:計算引擎已列待補,守恆側視為無法驗證
+        return {
+          ...base,
+          reason: ArticulationViolationReasonEnum.UNPARSABLE_QUANTITY,
+          expectedConsumption: expected,
+          actualConsumption: actual,
+          gap: expected,
+        };
+      }
+      if (activity.unit === record.unit) {
+        actual = MoneyUtil.add(actual, parsed);
+      } else {
+        try {
+          actual = MoneyUtil.add(
+            actual,
+            UnitConverter.convert(parsed, activity.unit, record.unit).toString(),
+          );
+        } catch {
+          return {
+            ...base,
+            reason: ArticulationViolationReasonEnum.UNIT_MISMATCH,
+            expectedConsumption: expected,
+            actualConsumption: actual,
+            gap: expected,
+          };
+        }
+      }
+    }
+
+    // Info: (20260720 - Emily) 缺口 ≤ 預期消耗 × 損耗容差 → 合理損耗放行;預期為 0 時實際也必須為 0
+    const gap = MoneyUtil.abs(MoneyUtil.subtract(expected, actual));
+    const tolerance = MoneyUtil.multiply(expected, LOSS_RATIO_TOLERANCE);
+    const withinTolerance = MoneyUtil.toDecimal(gap).lte(
+      MoneyUtil.toDecimal(tolerance),
+    );
+    if (withinTolerance) return null;
+
+    return {
+      ...base,
+      reason: ArticulationViolationReasonEnum.MASS_GAP_EXCEEDS_TOLERANCE,
+      expectedConsumption: expected,
+      actualConsumption: actual,
+      gap,
+    };
+  }
+
+  // Info: (20260720 - Emily) 非庫存類合理性區間:超出物理量級邊界僅警示(per unit 常數;無法解析者交由計算引擎待補)
+  private checkPlausibility(
+    activities: IActivityRecord[],
+  ): IArticulationWarning[] {
+    const warnings: IArticulationWarning[] = [];
+    activities.forEach((activity) => {
+      if (isStockableUnit(activity.unit)) return;
+      const plausibleMax =
+        PLAUSIBILITY_MAX_BY_UNIT[activity.unit as MeasurementUnit];
+      if (!plausibleMax) return;
+      const parsed = parseActivityQuantity(activity.quantity);
+      if (!parsed) return;
+      if (MoneyUtil.toDecimal(parsed).gt(MoneyUtil.toDecimal(plausibleMax))) {
+        warnings.push({
+          activityKey: activityDedupeKey(activity),
+          sourceName: activity.sourceName,
+          reason: ArticulationWarningReasonEnum.QUANTITY_EXCEEDS_PLAUSIBLE_MAX,
+          quantity: parsed,
+          plausibleMax,
+          unit: activity.unit,
+        });
+      }
+    });
+    return warnings;
+  }
+}

--- a/src/services/carbon_articulation.service.ts
+++ b/src/services/carbon_articulation.service.ts
@@ -15,7 +15,8 @@ import {
   ArticulationViolationReasonEnum,
   ArticulationWarningReasonEnum,
 } from "@/constants/carbon_articulation";
-import { parseActivityQuantity } from "@/services/carbon_calculation.service";
+// Info: (20260720 - Emily) 從零依賴 lib 取用(不 import calculation service:它連動 EmissionFactorRepo → prisma)
+import { parseActivityQuantity } from "@/lib/carbon_quantity";
 import { activityDedupeKey } from "@/lib/carbon_inventory";
 import {
   IActivityRecord,

--- a/src/services/carbon_calculation.service.ts
+++ b/src/services/carbon_calculation.service.ts
@@ -16,6 +16,7 @@ import {
   CarbonPendingReasonEnum,
 } from "@/constants/carbon_calculation";
 import { activityDedupeKey } from "@/lib/carbon_inventory";
+import { parseActivityQuantity } from "@/lib/carbon_quantity";
 import {
   IActivityRecord,
   IComputedLedger,
@@ -52,18 +53,9 @@ const defaultFactorLookup: IFactorLookup = {
   },
 };
 
-/**
- * Info: (20260716 - Emily) 數量字串決定性解析:全形轉半形、去千分位/空白;
- * 合法格式僅「非負十進位數」;其餘(科學記號/負數/文字)回 null → 待補,絕不猜。
- */
-export const parseActivityQuantity = (raw: string): string | null => {
-  const halfWidth = raw.replace(/[０-９．]/g, (ch) =>
-    ch === "．" ? "." : String.fromCharCode(ch.charCodeAt(0) - 0xfee0),
-  );
-  const cleaned = halfWidth.replace(/[,\s，]/g, "");
-  if (!/^\d+(\.\d+)?$/.test(cleaned)) return null;
-  return cleaned;
-};
+// Info: (20260720 - Emily) 數量解析抽至零依賴 lib(#6520 純邏輯呼叫端不得連動 prisma);
+// Info: (20260720 - Emily) re-export 維持既有呼叫端不變
+export { parseActivityQuantity };
 
 // Info: (20260716 - Emily) 係數單位正規化:完整字串或括號內代碼比對別名表;無法正規化回 null
 export const normalizeCoefficientUnit = (

--- a/src/services/chat.service.ts
+++ b/src/services/chat.service.ts
@@ -26,6 +26,7 @@ import {
 } from "@/validators";
 import { GhgProtocolCategory } from "@/constants/esg";
 import { MeasurementUnit } from "@/constants/enums";
+import { CarbonChartTemplateEnum } from "@/constants/carbon_report_charts";
 import { IInventoryExtraction } from "@/types/carbon_chatbot.types";
 import { logger } from "@/lib/utils/logger";
 
@@ -37,6 +38,11 @@ export interface ICarbonChatStructuredReply {
   extraction: IInventoryExtraction | null;
   // Info: (20260716 - Emily) #55 修訂請求:使用者要求「依附件/指示修改既有段落」時的目標段落(白名單裁決後)
   revisionParagraphId: string | null;
+  // Info: (20260720 - Emily) #51 圖表請求(雙 enum 白名單裁決後):LLM 只裁決「哪張圖、放哪段」,數值零參與
+  chartRequest: {
+    templateId: CarbonChartTemplateEnum;
+    paragraphId: string;
+  } | null;
 }
 
 // Info: (20260714 - Emily) readyParagraphId 的無段落標記(LLM enum 選項之一)
@@ -78,6 +84,28 @@ const CARBON_CHAT_REPLY_SCHEMA: Schema = {
       enum: [...CARBON_REPORT_OUTLINE.map((s) => s.id), NO_READY_PARAGRAPH],
       description:
         "使用者要求依附件或指示『修改既有段落』時填該段 id;非修改請求一律 none",
+    },
+    // Info: (20260720 - Emily) #51 圖表請求:雙 enum 鎖死(模板白名單 × 段落清單);數值由系統產出
+    chartRequest: {
+      type: SchemaType.OBJECT,
+      description:
+        "使用者明確要求在指定段落加入圖表/表格時填寫;非圖表請求省略本欄位",
+      properties: {
+        templateId: {
+          type: SchemaType.STRING,
+          format: "enum",
+          enum: Object.values(CarbonChartTemplateEnum),
+          description:
+            "SCOPE_PIE=各範疇占比圓餅圖;SCOPE_BAR=各範疇長條圖;SOURCE_TABLE=排放源明細表",
+        },
+        paragraphId: {
+          type: SchemaType.STRING,
+          format: "enum",
+          enum: CARBON_REPORT_OUTLINE.map((s) => s.id),
+          description: "圖表插入的目標段落 id(只能從段落清單挑選)",
+        },
+      },
+      required: ["templateId", "paragraphId"],
     },
     // Info: (20260716 - Emily) #6518 事實萃取: enum 鎖死範疇/單位，數值原樣字串(嚴禁換算),TS 端再白名單複驗
     extraction: {
@@ -373,6 +401,7 @@ export class ChatService {
 - 資訊尚未齊全、仍在追問時 → 填 "${NO_READY_PARAGRAPH}"
 - 填入段落 id 後，系統會自動將該段草稿寫入右側報告；此時請在 reply 告知用戶「本段已寫入報告，可於右側預覽檢視」，不要把完整草稿貼在對話中，也不要再重複詢問同一段落。
 【段落修訂機制】使用者上傳新附件或明確要求「更新/修改某段」時 → revisionParagraphId 填該段 id(只能從段落清單挑選)，reply 告知「已產生修訂建議，請於預覽卡確認」；非修改請求一律填 "none"，且不要在 reply 貼修訂內容(由系統以對照卡呈現)。
+【圖表機制】使用者明確要求「在某段加圖表/表格」(如「在 3.2 加各範疇占比圓餅圖」)時 → chartRequest 填模板與目標段落(皆只能從列舉挑選)，reply 告知「圖表已由系統依勾稽數據插入該段」；圖表數值由系統決定性產出，嚴禁你在 reply 自繪任何圖表或表格；非圖表請求省略 chartRequest。
 【事實萃取機制】每輪回覆的 extraction 欄位，依下列規則萃取「用戶本輪訊息」中的盤查事實:
 - 企業名稱、盤查年度(西元)、組織邊界方法: 用戶明確提供時填入，原文照抄，不確定就省略。
 - activities: 用戶提供的活動數據(如用電量、油耗)。quantity 連同千分位「原樣照抄」為字串，嚴禁換算單位、加總或推導；單位只能從 unit 列舉挑選，對不上就整筆省略。
@@ -499,11 +528,29 @@ ${outlineCatalog}${langInstruction}`;
       )
         ? (rawRevision as string)
         : null;
+      // Info: (20260720 - Emily) #51:圖表請求雙欄位皆須通過白名單,任一非法即視為無請求(永不猜)
+      const rawChart = (rawParsed as { chartRequest?: unknown }).chartRequest;
+      const chartCandidate =
+        rawChart && typeof rawChart === "object"
+          ? (rawChart as { templateId?: unknown; paragraphId?: unknown })
+          : null;
+      const chartRequest =
+        chartCandidate &&
+        (Object.values(CarbonChartTemplateEnum) as unknown[]).includes(
+          chartCandidate.templateId,
+        ) &&
+        CARBON_REPORT_OUTLINE.some((s) => s.id === chartCandidate.paragraphId)
+          ? {
+              templateId: chartCandidate.templateId as CarbonChartTemplateEnum,
+              paragraphId: chartCandidate.paragraphId as string,
+            }
+          : null;
       return {
         reply: parsed.reply,
         readyParagraphId: isValidParagraph ? parsed.readyParagraphId : null,
         extraction,
         revisionParagraphId,
+        chartRequest,
       };
     } catch {
       return {
@@ -511,6 +558,7 @@ ${outlineCatalog}${langInstruction}`;
         readyParagraphId: null,
         extraction: null,
         revisionParagraphId: null,
+        chartRequest: null,
       };
     }
   }

--- a/src/services/chat.service.ts
+++ b/src/services/chat.service.ts
@@ -22,6 +22,7 @@ import {
   CarbonChatStructuredReplySchema,
   CarbonActivityRecordSchema,
   CarbonInventoryExtractionSchema,
+  CarbonStockRecordSchema,
 } from "@/validators";
 import { GhgProtocolCategory } from "@/constants/esg";
 import { MeasurementUnit } from "@/constants/enums";
@@ -123,6 +124,43 @@ const CARBON_CHAT_REPLY_SCHEMA: Schema = {
               },
             },
             required: ["scopeCategory", "sourceName", "quantity", "unit"],
+          },
+        },
+        // Info: (20260720 - Emily) #6520 物料庫存紀錄:期初/採購/期末原樣字串,供質量守恆勾稽
+        stockRecords: {
+          type: SchemaType.ARRAY,
+          items: {
+            type: SchemaType.OBJECT,
+            properties: {
+              materialName: {
+                type: SchemaType.STRING,
+                description: "物料名稱,須與活動數據的排放源名稱一致(如: 柴油)",
+              },
+              openingQuantity: {
+                type: SchemaType.STRING,
+                description: "期初庫存量,原樣照抄,嚴禁換算",
+              },
+              purchasedQuantity: {
+                type: SchemaType.STRING,
+                description: "本期採購量,原樣照抄,嚴禁換算",
+              },
+              closingQuantity: {
+                type: SchemaType.STRING,
+                description: "期末庫存量,原樣照抄,嚴禁換算",
+              },
+              unit: {
+                type: SchemaType.STRING,
+                format: "enum",
+                enum: Object.values(MeasurementUnit),
+              },
+            },
+            required: [
+              "materialName",
+              "openingQuantity",
+              "purchasedQuantity",
+              "closingQuantity",
+              "unit",
+            ],
           },
         },
       },
@@ -338,7 +376,8 @@ export class ChatService {
 【事實萃取機制】每輪回覆的 extraction 欄位，依下列規則萃取「用戶本輪訊息」中的盤查事實:
 - 企業名稱、盤查年度(西元)、組織邊界方法: 用戶明確提供時填入，原文照抄，不確定就省略。
 - activities: 用戶提供的活動數據(如用電量、油耗)。quantity 連同千分位「原樣照抄」為字串，嚴禁換算單位、加總或推導；單位只能從 unit 列舉挑選，對不上就整筆省略。
-- 你是萃取器不是計算機: 任何需要計算的內容一律不填。沒有可萃取的事實時 extraction 省略。
+- stockRecords: 用戶提供「期初庫存、本期採購、期末庫存」三值齊全的物料(燃料/原料)時填入，數值原樣照抄；materialName 須與該物料在活動數據中的排放源名稱一致；三值不齊全就整筆省略，嚴禁以 0 補位。
+- 你是萃取器不是計算機: 任何需要計算的內容一律不填(含庫存缺口、消耗量推算)。沒有可萃取的事實時 extraction 省略。
 【段落清單】
 ${outlineCatalog}${langInstruction}`;
   }
@@ -351,7 +390,7 @@ ${outlineCatalog}${langInstruction}`;
     value: unknown,
   ): IInventoryExtraction | null {
     if (!value || typeof value !== "object") return null;
-    const candidate = value as { activities?: unknown };
+    const candidate = value as { activities?: unknown; stockRecords?: unknown };
     const rawActivities = Array.isArray(candidate.activities)
       ? candidate.activities
       : [];
@@ -364,16 +403,31 @@ ${outlineCatalog}${langInstruction}`;
         dropped: rawActivities.length - activities.length,
       });
     }
+    // Info: (20260720 - Emily) #6520 庫存紀錄同標準裁決:逐筆驗證,壞欄位丟該筆不作廢整包
+    const rawStockRecords = Array.isArray(candidate.stockRecords)
+      ? candidate.stockRecords
+      : [];
+    const stockRecords = rawStockRecords.flatMap((item) => {
+      const parsed = CarbonStockRecordSchema.safeParse(item);
+      return parsed.success ? [parsed.data] : [];
+    });
+    if (rawStockRecords.length !== stockRecords.length) {
+      logger.warn("inventory extraction dropped invalid stock records", {
+        dropped: rawStockRecords.length - stockRecords.length,
+      });
+    }
     const orgParsed = CarbonInventoryExtractionSchema.safeParse({
       ...value,
       activities: [],
+      stockRecords: [],
     });
     const org = orgParsed.success ? orgParsed.data : { activities: [] };
     if (
       !org.company &&
       !org.year &&
       !org.boundaryApproach &&
-      activities.length === 0
+      activities.length === 0 &&
+      stockRecords.length === 0
     ) {
       return null;
     }
@@ -382,6 +436,7 @@ ${outlineCatalog}${langInstruction}`;
       year: org.year,
       boundaryApproach: org.boundaryApproach,
       activities,
+      stockRecords: stockRecords.length > 0 ? stockRecords : undefined,
     };
   }
 

--- a/src/types/carbon_chatbot.types.ts
+++ b/src/types/carbon_chatbot.types.ts
@@ -3,6 +3,11 @@
 
 import { GhgProtocolCategory } from "@/constants/esg";
 import { CarbonInventoryStep } from "@/constants/carbon_chatbot";
+import {
+  ArticulationStatusEnum,
+  ArticulationViolationReasonEnum,
+  ArticulationWarningReasonEnum,
+} from "@/constants/carbon_articulation";
 
 export enum ChatRoleEnum {
   USER = "user",
@@ -106,6 +111,49 @@ export interface IActivityRecord {
   source?: string;
 }
 
+/**
+ * Info: (20260720 - Emily) #6520 可盤點物料庫存紀錄(質量守恆等式的左側資料):
+ * 期初庫存 + 本期採購 = 本期投入(消耗) + 期末庫存。
+ * 數值以字串保存(嚴禁 number 運算);消耗側由同名活動數據(sourceName)加總對照。
+ */
+export interface IMaterialStockRecord {
+  materialName: string;
+  openingQuantity: string;
+  purchasedQuantity: string;
+  closingQuantity: string;
+  unit: string;
+  source?: string;
+}
+
+// Info: (20260720 - Emily) #6520 單筆守恆違反明細(等式兩側 Decimal 字串值透明呈現,審計可追溯)
+export interface IArticulationViolation {
+  materialName: string;
+  unit: string;
+  reason: ArticulationViolationReasonEnum;
+  // Info: (20260720 - Emily) 預期消耗 = 期初 + 採購 - 期末;實際消耗 = 同名活動數據加總
+  expectedConsumption: string;
+  actualConsumption: string;
+  gap: string;
+}
+
+// Info: (20260720 - Emily) #6520 合理性警示(非庫存類超出物理量級邊界;僅警示不凍結)
+export interface IArticulationWarning {
+  activityKey: string;
+  sourceName: string;
+  reason: ArticulationWarningReasonEnum;
+  quantity: string;
+  plausibleMax: string;
+  unit: string;
+}
+
+// Info: (20260720 - Emily) #6520 勾稽結果:REVIEW 步驟出口與 #23 數據段落凍結的唯一裁決來源
+export interface IArticulationResult {
+  status: ArticulationStatusEnum;
+  violations: IArticulationViolation[];
+  warnings: IArticulationWarning[];
+  checkedAt: string;
+}
+
 // Info: (20260716 - Emily) #6519 係數快照: 計算當下凍結採用的係數(稽核軌跡地基)
 export interface IFactorSnapshot {
   factorId: string;
@@ -143,6 +191,8 @@ export interface IComputedLedger {
   scopeSubtotals: Record<string, string>;
   totalCo2eKg: string;
   computedAt: string;
+  // Info: (20260720 - Emily) #6520 質量守恆勾稽結果(/calculate 一併回傳,隨 ledger E2EE 入庫)
+  articulation?: IArticulationResult;
 }
 
 // Info: (20260716 - Emily) #6518 LLM 事實萃取結果(已經 Zod + 白名單裁決;year 由 TS 決定性轉數字)
@@ -151,6 +201,8 @@ export interface IInventoryExtraction {
   year?: number;
   boundaryApproach?: ICarbonInventoryState["boundaryApproach"];
   activities: IActivityRecord[];
+  // Info: (20260720 - Emily) #6520 可盤點物料庫存紀錄(期初/採購/期末;守恆等式的驗證資料)
+  stockRecords?: IMaterialStockRecord[];
 }
 
 // Info: (20260712 - Luphia) 碳盤查結構化事實狀態：AI 的長期記憶與報告的資料來源（取代重播逐字對話）
@@ -163,6 +215,8 @@ export interface ICarbonInventoryState {
     | "financial_control"
     | "equity_share";
   activities: IActivityRecord[];
+  // Info: (20260720 - Emily) #6520 物料庫存紀錄(守恆檢核資料;與 activities 同軌合併去重)
+  stockRecords?: IMaterialStockRecord[];
   // Info: (20260716 - Emily) #6519 決定論引擎的計算總表(隨 state E2EE 入庫)
   computedLedger?: IComputedLedger;
   notes?: string[];

--- a/src/types/carbon_chatbot.types.ts
+++ b/src/types/carbon_chatbot.types.ts
@@ -55,11 +55,13 @@ export interface IChatMessage {
   relatedParagraphIds?: string[];
 }
 
+// Info: (20260720 - Emily) #23 emissions 改字串化 Decimal:值取自 computedLedger.scopeSubtotals,
+// Info: (20260720 - Emily) 全程不經 number(ADR 003);顯示端直接渲染,禁 .toFixed
 export interface IReportCategory {
   id: string;
   name: string;
   description: string;
-  emissions: number;
+  emissions: string;
 }
 
 export interface IReportParagraph {
@@ -95,7 +97,8 @@ export interface IReportData {
   section: string;
   categories: IReportCategory[];
   paragraphs?: IReportParagraph[];
-  totalEmissions: number;
+  // Info: (20260720 - Emily) #23 接真值:computedLedger.totalCo2eKg(字串化 Decimal,kg)
+  totalEmissions: string;
 }
 
 // Info: (20260712 - Luphia) 單筆活動數據（數值以字串保存，計算時於服務層轉 Decimal，避免浮點誤差）

--- a/src/validators/carbon_inventory.ts
+++ b/src/validators/carbon_inventory.ts
@@ -6,6 +6,12 @@ import { GhgProtocolCategory } from "@/constants/esg";
 import { MeasurementUnit } from "@/constants/enums";
 import { CarbonInventoryStep } from "@/constants/carbon_chatbot";
 import { CARBON_CALCULATE_MAX_ACTIVITIES } from "@/constants/carbon_calculation";
+import {
+  CARBON_ARTICULATION_MAX_STOCK_RECORDS,
+  ArticulationStatusEnum,
+  ArticulationViolationReasonEnum,
+  ArticulationWarningReasonEnum,
+} from "@/constants/carbon_articulation";
 import { CarbonReportDraftPutSchema } from "@/validators/carbon_report_storage";
 
 // Info: (20260716 - Emily) 單筆活動數據: scopeCategory/unit 以 nativeEnum 鎖死；quantity 原樣字串(嚴禁在此轉數字)
@@ -18,6 +24,16 @@ export const CarbonActivityRecordSchema = z.object({
   source: z.string().max(200).optional(),
 });
 
+// Info: (20260720 - Emily) #6520 物料庫存紀錄: 質量守恆等式資料;數值原樣字串(解析於 articulation 服務)
+export const CarbonStockRecordSchema = z.object({
+  materialName: z.string().min(1).max(100),
+  openingQuantity: z.string().min(1).max(50),
+  purchasedQuantity: z.string().min(1).max(50),
+  closingQuantity: z.string().min(1).max(50),
+  unit: z.nativeEnum(MeasurementUnit),
+  source: z.string().max(200).optional(),
+});
+
 // Info: (20260716 - Emily) LLM 萃取輸出: year 為字串原樣，由此決定性轉數字(1990-2100 合理性邊界)
 export const CarbonInventoryExtractionSchema = z.object({
   company: z.string().min(1).max(100).optional(),
@@ -26,6 +42,8 @@ export const CarbonInventoryExtractionSchema = z.object({
     .enum(["operational_control", "financial_control", "equity_share"])
     .optional(),
   activities: z.array(CarbonActivityRecordSchema).max(20).default([]),
+  // Info: (20260720 - Emily) #6520 庫存紀錄萃取(期初/採購/期末;守恆檢核的資料來源)
+  stockRecords: z.array(CarbonStockRecordSchema).max(20).optional(),
 });
 
 export type CarbonInventoryExtractionPayload = z.infer<
@@ -43,6 +61,11 @@ export const CarbonCalculateRequestSchema = z.object({
     )
     .min(1)
     .max(CARBON_CALCULATE_MAX_ACTIVITIES),
+  // Info: (20260720 - Emily) #6520 庫存紀錄一併送檢:計算 + 守恆勾稽同一請求(結果掛回 ledger.articulation)
+  stockRecords: z
+    .array(CarbonStockRecordSchema)
+    .max(CARBON_ARTICULATION_MAX_STOCK_RECORDS)
+    .optional(),
 });
 export type CarbonCalculateRequestPayload = z.infer<
   typeof CarbonCalculateRequestSchema
@@ -82,6 +105,33 @@ export const ComputedLedgerSchema = z.object({
   scopeSubtotals: z.record(z.string(), z.string()),
   totalCo2eKg: z.string().max(60),
   computedAt: z.string().max(50),
+  // Info: (20260720 - Emily) #6520 勾稽結果(等式兩側值透明保存,審計可追溯)
+  articulation: z
+    .object({
+      status: z.nativeEnum(ArticulationStatusEnum),
+      violations: z.array(
+        z.object({
+          materialName: z.string().max(100),
+          unit: z.string().max(50),
+          reason: z.nativeEnum(ArticulationViolationReasonEnum),
+          expectedConsumption: z.string().max(60),
+          actualConsumption: z.string().max(60),
+          gap: z.string().max(60),
+        }),
+      ),
+      warnings: z.array(
+        z.object({
+          activityKey: z.string().max(300),
+          sourceName: z.string().max(100),
+          reason: z.nativeEnum(ArticulationWarningReasonEnum),
+          quantity: z.string().max(60),
+          plausibleMax: z.string().max(60),
+          unit: z.string().max(50),
+        }),
+      ),
+      checkedAt: z.string().max(50),
+    })
+    .optional(),
 });
 
 // Info: (20260716 - Emily) 前端解密後的狀態驗證（壞資料 Fail Fast 丟棄，不入 React 狀態）
@@ -98,6 +148,8 @@ export const CarbonInventoryStateSchema = z.object({
       factorSource: z.string().max(200).optional(),
     }),
   ),
+  // Info: (20260720 - Emily) #6520 物料庫存紀錄(隨 state E2EE 保存)
+  stockRecords: z.array(CarbonStockRecordSchema).optional(),
   computedLedger: ComputedLedgerSchema.optional(),
   notes: z.array(z.string().max(500)).optional(),
   updatedAt: z.string().max(50),

--- a/src/validators/carbon_report_storage.ts
+++ b/src/validators/carbon_report_storage.ts
@@ -8,7 +8,8 @@ const ReportCategorySchema = z.object({
   id: z.string(),
   name: z.string(),
   description: z.string(),
-  emissions: z.number(),
+  // Info: (20260720 - Emily) #23 改字串化 Decimal;coerce 相容既有草稿的 number(0)不 Fail Fast 丟棄
+  emissions: z.coerce.string().max(60),
 });
 
 const ReportParagraphSchema = z.object({
@@ -29,7 +30,8 @@ export const CarbonReportDataSchema = z.object({
   section: z.string(),
   categories: z.array(ReportCategorySchema),
   paragraphs: z.array(ReportParagraphSchema).optional(),
-  totalEmissions: z.number(),
+  // Info: (20260720 - Emily) #23 改字串化 Decimal;coerce 相容既有草稿的 number
+  totalEmissions: z.coerce.string().max(60),
   // Info: (20260716 - Emily) 報告全文權威來源(零改動保證;上限對齊密文欄位)
   rawMarkdown: z.string().max(2_000_000).optional(),
 });


### PR DESCRIPTION
### DEVELOP

 - carbon_report_table replace test: the "updated ledger" fixture only
  overrode scopeSubtotals/totalCo2eKg while entries kept the old co2e —
  the detail row legitimately still printed 1,235,000. The replace logic
  was correct; the fixture wasn't self-consistent. Entries now carry the
  new value too
- Worker force-exit warning: carbon_articulation.service imported
  parseActivityQuantity from carbon_calculation.service, which pulls
  EmissionFactorRepo → real prisma (pg Pool) into every suite that
  touches articulation. The parser is a zero-dependency pure function —
  extracted to src/lib/carbon_quantity.ts; the calculation service
  re-exports it so existing importers are unchanged, and pure-logic
  suites no longer open a DB pool
  
#### Related Issues

- [X] Issue Number:  Link the related issue (e.g., #123)

#### Checklist

- [x] Used `@` in import paths.
- [x] Verified naming convention compliance ([Naming Convention Guidelines](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md)).
- [x] Coding style verification: checked
- [x] new Library: 0
- [x] new Class / Component: 0
- [x] new loop: 0
- [x] new recursive: 0
- [x] high risk: 0
- [x] new sql: 0

#### UML Diagrams

- None

#### Additional Notes

- Ensured all links are up-to-date.
- Conducted thorough testing on responsive design changes.
- Documented any notable considerations or edge cases addressed.