### PR TITLE
chore(ci): gate on a project-wide type check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,6 +61,12 @@ jobs:
           # The database URL to connect to the PostgreSQL database
           DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres
 
+      # Info: (20260731 - Tzuhan) 全專案型別檢查:next build 只檢查應用相依圖可達的檔案,
+      # Info: (20260731 - Tzuhan) 測試檔沒被 import 就完全不檢查;eslint 不做型別推導、jest 走轉譯也不檢查,
+      # Info: (20260731 - Tzuhan) 因此測試檔的型別在此之前是沒有守門人的區域。排在測試之前:跑得快,且一次列出所有錯誤
+      - name: Type check
+        run: npx tsc --noEmit
+
       - name: Run unit tests & integration tests
         run: npm run test
         env:

--- a/src/lib/utils/__tests__/custom_matrix_editor.test.ts
+++ b/src/lib/utils/__tests__/custom_matrix_editor.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "@jest/globals";
 import {
   MatrixActionType,
   CustomChartConfigKey,


### PR DESCRIPTION
### DEVELOP

- [X] Description: 測試檔的型別在此之前是沒有守門人的區域:

- next build 只檢查應用相依圖可達的檔案,測試檔沒被 import 就不檢查
- npm run test 是 eslint + jest,前者不做型別推導,後者走轉譯也不檢查

實測結果是 custom_matrix_editor.test.ts 缺了 @jest/globals import(全專案 40+ 個測試檔只有它沒有),describe/it/expect 全是未定義名稱共 63 個錯誤, 而 CI 從來沒有反應。

- 補上該檔的 import,與既有慣例一致
- workflow 新增 npx tsc --noEmit,排在測試之前(跑得快,且一次列出所有錯誤, 不像 next build 只印第一個)

合併前請在乾淨的 develop 上跑一次 npx tsc --noEmit 確認為零 —— 沙箱因無法 下載 prisma engine 而有 4 個 stale client 造成的假錯誤,無法在此完全排除。

  
#### Related Issues

- [X] Issue Number:  #6577

#### Checklist

- [x] Used `@` in import paths.
- [x] Verified naming convention compliance ([Naming Convention Guidelines](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md)).
- [x] Coding style verification: checked
- [x] new Library: 0
- [x] new Class / Component: 0
- [x] new loop: 0
- [x] new recursive: 0
- [x] high risk: 0
- [x] new sql: 0

#### UML Diagrams

- None

#### Additional Notes

- Ensured all links are up-to-date.
- Conducted thorough testing on responsive design changes.
- Documented any notable considerations or edge cases addressed.