### PR TITLE
chore(gateway): raise proxy_read_timeout to 300s

### DIFF
--- a/dockerfiles/gateway/nginx.conf
+++ b/dockerfiles/gateway/nginx.conf
@@ -43,6 +43,14 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
+
+            # Info: (20260730 - Tzuhan) 安全網,非主要修正:此處原本未設 proxy_read_timeout,
+            # Info: (20260730 - Tzuhan) nginx 預設 60s,而碳盤查的附件→段落管線實測約 87s(萃取 36.8s + 3 段草稿),
+            # Info: (20260730 - Tzuhan) 使用者因此看到 504 與「系統錯誤」即使伺服端已跑完。
+            # Info: (20260730 - Tzuhan) 真正的修正是逐段經 Centrifugo 推播(結果不依賴此連線存活);
+            # Info: (20260730 - Tzuhan) 這裡放寬只是避免中途斷線的雜訊,不要靠它解決長工作。
+            proxy_read_timeout 300s;
+            proxy_send_timeout 300s;
         }
 
         location /connection/websocket {


### PR DESCRIPTION
### DEVELOP

- [X] Description: The gateway sets no proxy_read_timeout, so nginx's 60s default applies to every API. Any request that legitimately runs longer is cut off mid-flight and the browser sees a 504 even when the server completes - observed with an LLM pipeline that needs about 87s.

This is a safety net, not a fix. A request that needs minutes should deliver its result over a channel that does not depend on one connection staying open; relying on this timeout would just turn a 60-second spinner into a 300-second one. Raised so that ordinary long requests stop being truncated, and commented to that effect.
#### Related Issues

- [X] Issue Number: #6579

#### Checklist

- [x] Used `@` in import paths.
- [x] Verified naming convention compliance ([Naming Convention Guidelines](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md)).
- [x] Coding style verification: checked
- [x] new Library: 0
- [x] new Class / Component: 0
- [x] new loop: 0
- [x] new recursive: 0
- [x] high risk: 0
- [x] new sql: 0

#### UML Diagrams

- None

#### Additional Notes

- Ensured all links are up-to-date.
- Conducted thorough testing on responsive design changes.
- Documented any notable considerations or edge cases addressed.