### PR TITLE
refactor(worker): split into an external compute node and an internal ops node

### DIFF
--- a/.env.worker.example
+++ b/.env.worker.example
@@ -1,0 +1,30 @@
+#
+# Worker 節點專屬設定（`.env.worker`）
+#
+# worker 不使用系統的 `.env`，也不讀取資料庫 —— 它只讀這一份。
+# 複製本檔為 `.env.worker` 後填值：cp .env.worker.example .env.worker
+#
+# 為什麼獨立一份：
+#   1. `MissionExecutor` 處理使用者上傳的憑證內容，依
+#      documents/architecture/async_workers/00_async_worker_overview.md
+#      它連主資料庫都不該連得到。與 web 節點共用 `.env` 會讓它看得到
+#      DATABASE_URL / SECRET_VAULT_MASTER_KEY / SUPER_ADMIN_*，
+#      而一個處理外部輸入的節點持有信任根，等於把那道隔離的意義抵銷掉。
+#   2. 只保留 worker 真正用到的鍵，而不是整份 web 設定。
+#   3. worker 本來就設計成可以放在另一台機器 —— 那時它不會有 web 的 `.env`。
+#
+# 這一份**不會**被 validateEnvDetailed() 當成必要鍵檢查（那支只讀 `.env.example`），
+# 所以這裡可以照常寫成鍵值，缺鍵不會讓系統掉進「尚未初始化」狀態。
+#
+
+# LLM 金鑰。web 節點的正式來源是資料庫的 system_setting（/admin/settings），
+# 但這個節點讀不到資料庫，因此對它而言金鑰就是部署環境差異。
+# **/admin/settings 的輪替與撤銷對 worker 無效** ——
+# 見 documents/engineering_guidelines/known_issues/executor_settings_isolation.md
+GEMINI_API_KEY=
+
+# 模型名稱。未設定時使用程式碼預設值（DEFAULT_GEMINI_MODEL）。
+MODEL=
+
+# 任務檔案的落地目錄（相對於 worker 的工作目錄）。未設定時預設 missions。
+MISSION_DIR=

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+# Info: (20260812 - Luphia) 範本必須進版控 —— 它是「worker 需要哪些鍵」的唯一說明。
+# `.env.example` 是在這條規則之前就被追蹤的，所以不需要例外；新加的範本需要。
+!.env.worker.example
 
 # vercel
 .vercel

--- a/documents/architecture/async_workers/00_async_worker_overview.md
+++ b/documents/architecture/async_workers/00_async_worker_overview.md
@@ -39,7 +39,7 @@ graph TD
     Issuer -- "上傳 mission.json (透過 DocumentHelper 切塊編碼)" --> IPFS
     Issuer -- "createTask (鎖定資金)" --> MissionBoard
     Issuer -- "寫入 plan.validator.md (防作弊標準)" --> IssueDir[/"本地 ISSUE_DIR"/]:::local
-    
+
     MissionBoard -- "偵測 Open 任務" --> Planner
     Planner -- "下載憑證 mission.json (透過 DocumentHelper 恢復切塊)" --> IPFS
     Planner -- "建立 plan.executor.json" --> MissionDir
@@ -70,38 +70,46 @@ graph TD
 系統的狀態流轉完全交由智能合約接管，Node.js 端的這 8 支微服務**互不認識、不直接呼叫彼此**，只透過聆聽區塊鏈與本機檔案目錄來決定下一步動作 (Event-Driven & Shared-Nothing Architecture)。
 
 ### 0. `TxTracker` (金流追蹤員)
+
 - **職責**：Web3 到 Web2 的訂單狀態同步器。
 - **動作**：不斷輪詢智能合約或區塊鏈節點，追蹤使用者的支付交易 (Tx)。一旦確認款項入帳 (`Success`)，立刻將 PostgreSQL 中的 Order 狀態更新為 `PAID`，正式啟動後續的發包流程。
 
 ### 1. `MissionIssuer` (發包員)
+
 - **職責**：Web2 到 Web3 的實體橋樑。
 - **動作**：不斷輪詢資料庫中狀態為 `PAID` 的訂單。找到後，向區塊鏈送出 `Approve` (授權扣款) 與 `createTask` (鑄造 NFT)，將使用者的原始憑證 `contentCid` 永久綁定，完成資金信託 (Escrow)。
 
 ### 2. `MissionPlanner` (調度員)
+
 - **職責**：任務準備與在地化。
 - **動作**：聆聽智能合約上狀態為 `Open (0)` 的任務。拿到任務後，從 IPFS 下載使用者的原始 `mission.json`，並在本地建立隔離的 `MISSION_DIR`，同時產出供 AI 讀取的 `plan.executor.json`。
 
 ### 3. `MissionExecutor` (推論引擎) 與決定論管線 (Deterministic Pipeline)
+
 - **職責**：系統的算力心臟，執行純粹的 AI 推論，並在寫入磁碟前透過決定論管線洗淨資料。
 - **動作**：掃描 `MISSION_DIR` 執行 AI 推論。在將結果寫入 `result.md` 前，**此處是決定論攔截器管線 (VoucherPipelineOrchestrator) 的唯一觸發點**。系統會偵測 Payload 並依序啟動：
   1. **TaxStrategyService**：偵測非本地統編，自動補齊 1423 / 2941 境外電商逆向稅額。
   2. **FxInterceptorService**：套用高精度匯率轉換，並處理借貸尾差配平 (Plug)。
   3. **AccountingEngineService**：執行應計基礎 (Accrual Basis) 跨期切斷 (Cut-off)。
-  清洗完成後，將最終結果寫成 `result.md`。若發生錯誤，除了寫入 `failed_*.md` 外，**會刻意輸出帶有錯誤標記的 `result.md` 以推進狀態機至後續的退回流程**。若偵測到 `giveup.md` 則會直接跳過。
+     清洗完成後，將最終結果寫成 `result.md`。若發生錯誤，除了寫入 `failed_*.md` 外，**會刻意輸出帶有錯誤標記的 `result.md` 以推進狀態機至後續的退回流程**。若偵測到 `giveup.md` 則會直接跳過。
 
 ### 4. `MissionCommitor` (上鏈員)
+
 - **職責**：產出保護與提交。
 - **動作**：掃描本地 `MISSION_DIR` 找出執行完畢的 `result.md`，並將其切塊加密上傳至 Laria 取得 `resultCid`。**同時，讀取 `execution_log.json` 總結 AI Token 消耗量**，將兩者一併透過 `submitResult` 送交合約，將任務推至 `PendingReview (1)`。
 
 ### 5. `IssueValidator` (自動化查帳員)
+
 - **職責**：取代傳統的人工覆核 (HITL)。
 - **動作**：聆聽合約上 `PendingReview` 的任務。將 IPFS 上的結果下載後進行規則驗證（例如確認 AI 信心度是否為滿分）。若驗證無誤，發送 `approveSubmission` 交易解鎖資金並放行任務。
 
 ### 6. `MissionRecorder` (總帳抄寫員)
+
 - **職責**：將 Web3 的客觀真相轉換為 Web2 的財務真相，並寫回總帳。
 - **動作**：掃描本地 `ISSUE_DIR` 尋找 Validator 留下的 `approved.*.md`。**作為絕對愚蠢的寫入器 (Dumb Writer)，它不再攔截或修改任何資料**。它僅單純地將 `approved.*.md` 內的 `dbSyncPayload` 安全地寫回 PostgreSQL 總帳本，並將原本的訂單標記為 `COMPLETED`。
 
 ### 7. `MissionFallbacker` (結算與回收員)
+
 - **職責**：任務最終狀態的結算與死信佇列 (DLQ) 處理。
 - **動作**：定期巡視任務最終狀態。若任務已在鏈上核准 (Approved)，則精算 Token 耗損與利潤率並寫入 `close.md` 結案；若任務被拒絕達 3 次，則寫入 `giveup.md` 打入死信佇列。(TODO: 未來實作合約的 `raiseDispute` 爭議仲裁機制)
 
@@ -110,27 +118,39 @@ graph TD
 ## 🏆 架構師評價與防禦機制實作 (Architectural Defenses)
 
 ### 🔐 零資料庫存取與安全隔離 (Zero DB Access & Security Boundary)
+
 系統劃下了一道不可踰越的安全鴻溝：**`MissionExecutor` (與其他所有負責 Web3 / AI 運算的外部節點) 絕對沒有存取主系統 PostgreSQL 資料庫的權限。**
+
+> ⚠️ **實作與本節不符（2026-08-12，Luphia）**：行程已於此日拆成「外部運算節點」（`npm run worker:compute`）與「內部維運節點」（`npm run worker:ops`），但**運算節點目前仍有兩處真實的資料庫查詢**，都是為了取排放係數字典：`voucher.pipeline.orchestrator` 的 `getCoefficientById()` 與 `skills/document/esg_parsing` 的 `getAllGlobalCoefficients()`。
+> 也就是說本節這句「絕對沒有權限」目前是**目標而非事實**。`src/__tests__/worker_node_isolation.test.ts` 以匯入圖掃描把這兩條清單化：新增任何耦合會讓測試變紅，已知的兩條是明示例外。解法與取捨見 **[已知缺陷](../../engineering_guidelines/known_issues/executor_settings_isolation.md)**。
+
 - **物理隔離**：它們無法連線 DB，更無法直接寫入、修改或刪除任何帳本資料。
 - **單向提議**：它們的輸出 (`result.md`) 僅是一份「提議載荷 (Payload)」，必須經過上鏈 (`MissionCommitor`)、查帳核准 (`IssueValidator`)，最終由具備寫庫權限的內部節點 `MissionRecorder` 負責抄寫回資料庫。
 - **防禦提示詞注入 (Prompt Injection Guard)**：這種極端的隔離確保了即使 AI 遭到惡意使用者的「提示詞注入攻擊」，攻擊者也絕對無法穿越實體網路邊界去污染或竊取核心財務資料庫。
 
 ### 🛡️ 徹底隔離的檔案系統 (Shared-Nothing Architecture)
+
 由於 Planner 與 Executor 依賴的是本地的檔案系統狀態機，這意味著多個 Worker 之間**完全不需要共用掛載硬碟 (Shared Volume)**。
 因為沒有共用硬碟，自然就從物理層面徹底消滅了分散式擴展時最難解的「競爭條件 (Race Condition)」。系統不需要實作任何 Redis Lock，K8s 的橫向擴展變得極度輕量、純粹且具備無限擴展性。
 
 ### 🏗️ 混合決定論管線 (Hybrid Deterministic Pipeline)
+
 Executor 的內部實作了「不確定的機率推論」與「絕對的數學真理」拆分。
+
 1. **任務層級分流 (`skillRegistry` 與 RAG 管線)**：判斷是否為預先寫死的 TypeScript 技能，透過本地 Vector Search 提供動態決策選項 (`EsgParsingSkill` 採 Two-Turn AI 決策；`VoucherLinesParsingSkill` 採單回合萃取並搭配後端 Bigram 嚴格懸記)。
 2. **AI 推論 Fallback**：若皆無命中，才會退回到純粹的 Gemini API 請求。所有產出預設為 `isVerified: false`。
 
 ### 🧮 數值型別防腐層 (Type Flow & Anti-Corruption)
+
 整個管線嚴格管制數值型別：
+
 1. **AI 萃取期 (Volatile JSON)**：視為原生 `number`，未受信任。
 2. **型別鑄造 (Type Casting)**：強制轉為 `BigInt` (財務金額) 或 `Decimal` (碳排係數)。
 3. **資料庫與聚合防禦**：全面透過基於 `Decimal.js` 的 `MoneyUtil` 防腐層進行後續運算，並受到 Prisma Boundary Guard 的嚴密保護，徹底阻絕浮點數漂移。
 
 ### 📦 隱藏的底層英雄：DocumentHelper 與 Laria 儲存層
+
 在架構圖中未被獨立列出為 Daemon，但扮演關鍵角色的 `DocumentHelper`，是我們去中心化檔案儲存的基石：
+
 - **切塊編碼 (Sharding)**：當 `MissionIssuer` 準備將任務上傳時，`DocumentHelper` 會在背景將實體檔案切碎（如將 593 bytes 切割為 8 個 119 bytes 的 shards），以符合分散式網路的傳輸標準。
 - **組裝恢復 (Recovery)**：當 `MissionPlanner` 接到任務時，`DocumentHelper` 會在背景將這 8 個切片自動找齊並無縫還原回實體檔案 (`Recovered file successfully`)。這使得上層的 Daemons 完全不需要處理複雜的 IPFS/Laria 下載與解碼邏輯。

--- a/documents/engineering_guidelines/known_issues/executor_settings_isolation.md
+++ b/documents/engineering_guidelines/known_issues/executor_settings_isolation.md
@@ -21,7 +21,11 @@
 
 那道隔離不是潔癖，是**防提示詞注入的基礎** —— Executor 處理使用者上傳的憑證內容，即使注入成功也必須穿不過實體網路邊界（ADR 009 的「單向黃金法則」建立在同一個前提上）。
 
-為了取一把金鑰而讓它連上主資料庫，等於把那個安全論證的前提拿掉。依專案規則「一個設定只有一個來源」（ADR 017 §7 的規則章節），對這個節點而言 `.env` 就是**唯一**來源而不是 fallback：金鑰與 `MISSION_DIR` 都取自 `loadEnvConfig(ENV_PATH)`，刻意不用 `getPriorityEnvConfig()`（那是「`.env.setup` 優先，否則 `.env`」兩個來源，而 `.env.setup` 簽章後會被清空），也不讀 `process.env`（worker 由 `npx tsx` 啟動，沒有任何地方把 `.env` 載進去，`ecosystem.config.json` 只給 `NODE_ENV`）。
+為了取一把金鑰而讓它連上主資料庫，等於把那個安全論證的前提拿掉。依專案規則「一個設定只有一個來源」（ADR 017 §7 的規則章節），worker 有**自己的**設定檔 `.env.worker`：既不吃系統的 `.env`，也不讀資料庫。`run_worker.ts` 啟動時把它載進 `process.env`（在任何 service 被呼叫之前），Executor 則直接 `loadWorkerEnvConfig()`。範本見 `.env.worker.example`。
+
+**為什麼不共用系統 `.env`**：那份裡有 `DATABASE_URL`、`SECRET_VAULT_MASTER_KEY`、`SUPER_ADMIN_*`。Executor 處理的是使用者上傳的憑證內容，而它連資料庫都不該連得到 —— 讓它持有信任根，等於把那道隔離的意義抵銷掉。共用一份 `.env` 是「順手」，不是「隔離」。
+
+**找不到 `.env.worker` 時不 fallback 到系統 `.env`**：`run_worker` 會大聲記錄一筆 error 並繼續（不 `process.exit`，理由見下節），Executor 則在真正需要金鑰時失敗。悄悄改用 web 那份會讓隔離在「剛好沒建檔」時失效，而那正是最不容易發現的情形。
 
 Executor 以 `new ChatService(apiKey, { allowSystemSettings: false })` 明示不查設定；`llm_key_resolution.test.ts` 有兩支測試釘住「呼叫次數為 0」與「Executor 確實傳了那個旗標」。
 
@@ -41,3 +45,26 @@ Executor 以 `new ChatService(apiKey, { allowSystemSettings: false })` 明示不
 - `documents/architecture/decisions/017_signed_system_settings_in_database.md`（§7 補充）
 - `documents/architecture/async_workers/00_async_worker_overview.md`
 - `src/services/mission.executor.service.ts`、`src/services/chat.service.ts`
+
+## 尚未拆分：同一個 worker 行程裡有必須存取資料庫的任務
+
+`scripts/run_worker.ts` 在**同一個行程**裡跑 12 個迴圈，其中至少五個必須存取主資料庫：
+
+- `TransactionTracker`（`order.tracker.service`）
+- `WalletGuardian`（`cron/wallet_audit.cron`）
+- 訂閱到期與續約（`cron/subscription_expiry.cron`、`cron/subscription_renewal.cron`）
+- `IssueRecorder`（`issue.recorder.service`，寫回帳本是它的工作）
+- `ExchangeRateSync`（`cron/exchange_rate.cron`）
+
+也就是說「worker 不讀資料庫」在**目前的行程結構下不可能成立** —— 它對 `MissionExecutor` 與 mission 管線（純檔案狀態機）成立，對這些 cron／tracker 不成立。文件所述的「Executor 作為無資料庫權限的外部節點」與「現在的 worker 行程」不是同一件事。
+
+要真正落實，需要把行程拆成兩種角色：
+
+| 角色         | 內容                            | 設定來源      | 資料庫 |
+| ------------ | ------------------------------- | ------------- | ------ |
+| 外部運算節點 | `MissionExecutor`、mission 管線 | `.env.worker` | 無     |
+| 內部維運節點 | tracker、cron、recorder         | 系統 `.env`   | 有     |
+
+那是部署與架構決定（要多一個 pm2 app、多一份設定、以及決定 `MISSION_DIR` 如何在兩者間交換檔案），不在單次程式碼改動的範圍內。**在拆分完成之前，`.env.worker` 只涵蓋 Executor 用到的鍵**；其餘 worker 端服務仍透過 `getPriorityEnvConfig()` 讀系統 `.env`（`issue.service`、`mission.planner` / `commitor` / `closer`、`issue.validator`、`issue.recorder`、`order.backfill`、`cron/amortization.worker`、`admin.blockchain`）。
+
+**不要**為了「讓 worker 完全不碰系統 `.env`」而把上述服務一次改掉：它們有幾支需要的正是資料庫連線，改完會直接停擺。

--- a/documents/engineering_guidelines/known_issues/executor_settings_isolation.md
+++ b/documents/engineering_guidelines/known_issues/executor_settings_isolation.md
@@ -46,7 +46,40 @@ Executor 以 `new ChatService(apiKey, { allowSystemSettings: false })` 明示不
 - `documents/architecture/async_workers/00_async_worker_overview.md`
 - `src/services/mission.executor.service.ts`、`src/services/chat.service.ts`
 
-## 尚未拆分：同一個 worker 行程裡有必須存取資料庫的任務
+## 已拆分（2026-08-12）：兩個節點
+
+| 角色         | 啟動                     | 內容                                                                                                      | 設定來源      | 資料庫                 |
+| ------------ | ------------------------ | --------------------------------------------------------------------------------------------------------- | ------------- | ---------------------- |
+| 外部運算節點 | `npm run worker:compute` | MissionPlanner / Executor / Commitor / Closer（同一個 `MISSION_DIR` 上的檔案狀態機）                      | `.env.worker` | **目標為無**（見下）   |
+| 內部維運節點 | `npm run worker:ops`     | TransactionTracker、IssueService、IssueValidator、IssueRecorder、匯率、攤提、錢包守恆勾稽、訂閱到期與續約 | 系統 `.env`   | 有（寫庫就是它的工作） |
+
+`ecosystem.config.json` 已宣告成兩個 pm2 app（`isunfa-compute` / `isunfa-ops`）。`npm run worker` 保留為**會退出並印出指示**的入口 —— 讓它繼續跑兩邊等於拆分對既有部署無效，而讓它只跑一半會使 mission 管線**靜默停止**（沒有錯誤，只有任務不再前進）。
+
+分類依據是逐一驗證過的執行期匯入圖，不是文件敘述。過程中發現五條「幽靈耦合」：那些檔案只用到 `document_parser_db_sync` 的**型別**卻寫成值匯入，於是把 `document_sync.repo → lib/prisma` 整條拉進運算節點的模組圖，已改為 `import type`。`chat.service` 對 `system_setting.service` 的匯入也改為動態（只有真的要查設定時才載入）。
+
+### 拆分後仍存在的耦合：排放係數字典
+
+運算節點還有**兩處真實的資料庫查詢**，主題相同：
+
+1. `voucher.pipeline.orchestrator` → `EmissionFactorRepo.getCoefficientById()`（第 124、173 行；`mission.executor.service:521` 會走到）
+2. `skills/document/esg_parsing` → `EmissionFactorRepo.getAllGlobalCoefficients()`（第 166 行；經 `skills/index.ts` 被 Executor 取用）
+
+所以 `00_async_worker_overview.md` 那句「絕對沒有存取主資料庫的權限」目前是**目標而非事實**，而且不是匯入寫法的意外 —— 是兩次真正的查詢。三條可能的出路：
+
+| 出路                                | 代價                                                                     |
+| ----------------------------------- | ------------------------------------------------------------------------ |
+| Planner 預先把係數解析進 mission 檔 | 運算節點真正零資料庫；但係數在任務排入時就凍結，跨日的長任務可能用到舊值 |
+| 維運節點提供係數查詢 API            | 維持隔離（跨界改成 HTTP，符合單向模型）；多一條內部端點與其認證          |
+| 給運算節點唯讀的係數表權限          | 最省事；但「沒有資料庫可達性」這個前提消失，而那正是防提示詞注入的基礎   |
+
+`src/__tests__/worker_node_isolation.test.ts` 以集合比對把這兩條清單化 —— **新增任何一條耦合都會變紅**，已知的兩條不會讓測試長期紅著。第一版寫成「只找第一條路徑」時漏掉了 `esg_parsing` 那條，改成蒐集全部可達的匯入點才現形。
+
+### 尚未處理
+
+- 其餘 worker 端服務仍透過 `getPriorityEnvConfig()` 讀系統 `.env`（`issue.service`、`issue.validator`、`issue.recorder`、`order.backfill`、`cron/amortization.worker`、`admin.blockchain`）。它們都在**維運**節點上，讀系統 `.env` 是正確的 —— 不需要改。
+- `issue.recorder` 讀 `MISSION_DIR/<folder>/execution_log.json` 取 token 計數，那段在 `try {} catch {}` 內。拆成兩個節點（不共用磁碟）之後這個檔案讀不到，token 計數會落回結果載荷裡的值。**盡力而為的行為不變，但數字來源會變** —— 若要精確計數，需由運算節點把 log 併入結果載荷。
+
+## 拆分前的狀況（保留作為脈絡）
 
 `scripts/run_worker.ts` 在**同一個行程**裡跑 12 個迴圈，其中至少五個必須存取主資料庫：
 

--- a/ecosystem.config.json
+++ b/ecosystem.config.json
@@ -9,9 +9,17 @@
       }
     },
     {
-      "name": "isunfa-worker",
+      "name": "isunfa-compute",
       "script": "npm",
-      "args": "run worker",
+      "args": "run worker:compute",
+      "env": {
+        "NODE_ENV": "production"
+      }
+    },
+    {
+      "name": "isunfa-ops",
+      "script": "npm",
+      "args": "run worker:ops",
       "env": {
         "NODE_ENV": "production"
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "test:tz": "node scripts/jest_tz.mjs",
     "swarm": "npm run build && next start -p 10020",
     "worker": "npx tsx scripts/run_worker.ts",
+    "worker:compute": "npx tsx scripts/run_compute_node.ts",
+    "worker:ops": "npx tsx scripts/run_ops_node.ts",
     "executor": "npx tsx scripts/run_executor.ts",
     "format": "prettier --ignore-path .gitignore --write \"**/*.+(js|ts|json)\"",
     "integration_test": "npx tsx scripts/run_integration_test.ts",

--- a/scripts/executor_worker.ts
+++ b/scripts/executor_worker.ts
@@ -3,13 +3,26 @@ import dotenvExpand from "dotenv-expand";
 import path from "path";
 import fs from "fs";
 
-// Info: (20260521 - Luphia) Load env variables from the project root .env first
+/**
+ * Info: (20260812 - Luphia) 讀 `.env.worker`，不是系統的 `.env`。
+ *
+ * 這支是外部運算節點的單一 Executor 入口（由 `run_executor.ts` 併發啟動多份），
+ * 與 `run_compute_node.ts` 屬同一類節點，設定來源必須一致 ——
+ * 系統 `.env` 裡有 `DATABASE_URL`、`SECRET_VAULT_MASTER_KEY`、`SUPER_ADMIN_*`，
+ * 一個處理使用者上傳內容的節點不該看得到那些。
+ *
+ * 保留 dotenv-expand:這支原本就支援 `${VAR}` 展開，換檔案不該順手改掉那個語意。
+ */
 const projectRoot = process.cwd();
-const srcEnv = path.join(projectRoot, ".env");
+const workerEnv = path.join(projectRoot, ".env.worker");
 
-if (fs.existsSync(srcEnv)) {
-  const defaultEnv = dotenv.config({ path: srcEnv });
-  dotenvExpand.expand(defaultEnv);
+if (fs.existsSync(workerEnv)) {
+  const loaded = dotenv.config({ path: workerEnv });
+  dotenvExpand.expand(loaded);
+} else {
+  console.error(
+    `[Executor Worker] No configuration at ${workerEnv}. This node does not fall back to the system .env.`,
+  );
 }
 
 // Info: (20260521 - Luphia) Import service, ensuring they are resolved using the project root paths

--- a/scripts/run_compute_node.ts
+++ b/scripts/run_compute_node.ts
@@ -1,0 +1,84 @@
+import { processNext as processMissionPlannerNext } from "@/services/mission.planner.service";
+import { processNext as processMissionExecutorNext } from "@/services/mission.executor.service";
+import { processNext as processMissionCommitorNext } from "@/services/mission.commitor.service";
+import { processNext as processMissionCloserNext } from "@/services/mission.closer.service";
+import { installWorkerShutdownHandlers } from "@/lib/worker/shutdown";
+import { startServiceLoop } from "@/lib/worker/service_loop";
+import { ENV_WORKER_PATH, loadWorkerEnvConfig } from "@/services/env.service";
+
+const NODE_NAME = "ComputeNode";
+
+/**
+ * Info: (20260812 - Luphia) 外部運算節點：mission 管線，無資料庫、無系統 `.env`。
+ *
+ * ## 為什麼要與維運任務分開
+ *
+ * `async_workers/00_async_worker_overview.md` 劃下的隔離是**防提示詞注入的基礎**：
+ * 這個節點處理使用者上傳的憑證內容，即使注入成功也必須穿不過實體網路邊界。
+ * 而在拆分之前，同一個行程裡還跑著 `TransactionTracker`、`WalletGuardian`、
+ * 訂閱續約 —— 那些必須連資料庫，於是「Executor 沒有資料庫權限」在程式碼層面
+ * 只是一句話：行程有連線，Executor 只是剛好沒用。
+ *
+ * 拆開之後那句話變成部署事實：這個行程的容器／機器**不需要**（也不該有）
+ * 資料庫網路可達性與憑證。
+ *
+ * ## 這四個迴圈為什麼在一起
+ *
+ * planner → executor → commitor → closer 是同一個 `MISSION_DIR` 上的檔案狀態機，
+ * 必須共用同一個檔案系統。四者都不碰資料庫（已逐一驗證匯入圖）。
+ *
+ * ## 設定
+ *
+ * 只讀 `.env.worker`（見 `.env.worker.example`）。不吃系統 `.env` —— 那份裡有
+ * `DATABASE_URL`、`SECRET_VAULT_MASTER_KEY`、`SUPER_ADMIN_*`，一個處理外部輸入的
+ * 節點持有信任根，等於把隔離的意義抵銷掉。
+ */
+async function loadNodeEnv(): Promise<void> {
+  const config = await loadWorkerEnvConfig();
+  const keys = Object.keys(config);
+
+  if (keys.length === 0) {
+    console.error(
+      `[${NODE_NAME}] No configuration found at ${ENV_WORKER_PATH}. ` +
+        "This node does not fall back to the system .env — copy .env.worker.example and fill it in.",
+    );
+    return;
+  }
+
+  keys.forEach((key) => {
+    process.env[key] = config[key];
+  });
+  console.log(`[${NODE_NAME}] Loaded ${keys.length} settings from .env.worker`);
+}
+
+async function runComputeNode() {
+  await loadNodeEnv();
+
+  // Info: (20260811 - Luphia) 兩段式中斷 + 結束前釋放 mission 執行鎖
+  installWorkerShutdownHandlers(NODE_NAME);
+
+  console.log(`[${NODE_NAME}] Starting mission pipeline loops...`);
+
+  await Promise.all([
+    startServiceLoop(NODE_NAME, "MissionPlanner", () =>
+      processMissionPlannerNext(),
+    ),
+    startServiceLoop(NODE_NAME, "MissionExecutor", () =>
+      processMissionExecutorNext(),
+    ),
+    startServiceLoop(NODE_NAME, "MissionCommitor", () =>
+      processMissionCommitorNext(),
+    ),
+    startServiceLoop(NODE_NAME, "MissionCloser", () =>
+      processMissionCloserNext(),
+    ),
+  ]);
+
+  console.log(`[${NODE_NAME}] Stopped.`);
+  process.exit(0);
+}
+
+runComputeNode().catch((err) => {
+  console.error(`[${NODE_NAME}] Fatal error:`, err);
+  process.exit(1);
+});

--- a/scripts/run_ops_node.ts
+++ b/scripts/run_ops_node.ts
@@ -1,0 +1,89 @@
+import { scanPendingTransactions } from "@/services/order.tracker.service";
+import { processNext as processIssueNext } from "@/services/issue.service";
+import { processNext as processIssueValidatorNext } from "@/services/issue.validator.service";
+import { issueRecorderService } from "@/services/issue.recorder.service";
+import { syncExchangeRates } from "@/services/cron/exchange_rate.cron";
+import { processAmortization } from "@/services/cron/amortization.worker.service";
+import { runWalletGuardian } from "@/services/cron/wallet_audit.cron";
+import { expireOverdueTeamSubscriptions } from "@/services/cron/subscription_expiry.cron";
+import { processSubscriptionRenewals } from "@/services/cron/subscription_renewal.cron";
+import { installWorkerShutdownHandlers } from "@/lib/worker/shutdown";
+import { startServiceLoop } from "@/lib/worker/service_loop";
+
+const NODE_NAME = "OpsNode";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+/**
+ * Info: (20260812 - Luphia) 內部維運節點：需要主資料庫寫入權限的常駐任務。
+ *
+ * 這裡的每一支都碰資料庫（逐一驗證過匯入圖）：訂單追蹤、議題流程、查帳核准、
+ * 抄寫回帳本、匯率、攤提、錢包守恆勾稽、訂閱到期與續約。
+ *
+ * 與外部運算節點分開的理由見 `run_compute_node.ts` 的檔頭：
+ * 那個節點處理使用者上傳的內容，不該連得到資料庫；而這裡正好相反 ——
+ * 它的工作就是寫庫，所以它必須留在可信網段內，也因此**不得**執行
+ * mission 管線那些吃外部輸入的任務。
+ *
+ * 設定沿用系統 `.env`（與拆分前相同）。
+ */
+async function runOpsNode() {
+  // Info: (20260811 - Luphia) 兩段式中斷 + 結束前釋放 mission 執行鎖
+  installWorkerShutdownHandlers(NODE_NAME);
+
+  console.log(`[${NODE_NAME}] Starting maintenance loops...`);
+
+  await Promise.all([
+    startServiceLoop(NODE_NAME, "TransactionTracker", () =>
+      scanPendingTransactions(),
+    ),
+    startServiceLoop(NODE_NAME, "IssueService", () => processIssueNext()),
+    startServiceLoop(NODE_NAME, "IssueValidator", () =>
+      processIssueValidatorNext(),
+    ),
+    startServiceLoop(NODE_NAME, "IssueRecorder", () =>
+      issueRecorderService.processNext(),
+    ),
+    startServiceLoop(
+      NODE_NAME,
+      "ExchangeRateSync",
+      () => syncExchangeRates(),
+      8 * HOUR_MS,
+    ),
+    startServiceLoop(
+      NODE_NAME,
+      "AmortizationWorker",
+      () => processAmortization(),
+      HOUR_MS,
+    ),
+    // Info: (20260807 - Luphia) 團隊錢包守恆勾稽 + 每日 merkle 錨定（ADR 015 C 案 Phase 1）
+    startServiceLoop(
+      NODE_NAME,
+      "WalletGuardian",
+      () => runWalletGuardian(),
+      HOUR_MS,
+    ),
+    // Info: (20260807 - Luphia) 訂閱到期降級 / 標記續訂（fail-closed 防線在扣費側即時生效）
+    startServiceLoop(
+      NODE_NAME,
+      "SubscriptionExpiry",
+      () => expireOverdueTeamSubscriptions(),
+      HOUR_MS,
+    ),
+    // Info: (20260807 - Luphia) autoRenew 自動扣款續訂（逾 3 天寬限期未成即降級 free）
+    startServiceLoop(
+      NODE_NAME,
+      "SubscriptionRenewal",
+      () => processSubscriptionRenewals(),
+      HOUR_MS,
+    ),
+  ]);
+
+  console.log(`[${NODE_NAME}] Stopped.`);
+  process.exit(0);
+}
+
+runOpsNode().catch((err) => {
+  console.error(`[${NODE_NAME}] Fatal error:`, err);
+  process.exit(1);
+});

--- a/scripts/run_worker.ts
+++ b/scripts/run_worker.ts
@@ -1,137 +1,37 @@
-import { scanPendingTransactions } from "@/services/order.tracker.service";
-import { processNext as processIssueNext } from "@/services/issue.service";
-import { processNext as processMissionPlannerNext } from "@/services/mission.planner.service";
-import { processNext as processMissionExecutorNext } from "@/services/mission.executor.service";
-import { processNext as processMissionCommitorNext } from "@/services/mission.commitor.service";
-import { processNext as processMissionCloserNext } from "@/services/mission.closer.service";
-import { processNext as processIssueValidatorNext } from "@/services/issue.validator.service";
-import { issueRecorderService } from "@/services/issue.recorder.service";
-import { syncExchangeRates } from "@/services/cron/exchange_rate.cron";
-import { processAmortization } from "@/services/cron/amortization.worker.service";
-import { runWalletGuardian } from "@/services/cron/wallet_audit.cron";
-import { expireOverdueTeamSubscriptions } from "@/services/cron/subscription_expiry.cron";
-import { processSubscriptionRenewals } from "@/services/cron/subscription_renewal.cron";
-import {
-  installWorkerShutdownHandlers,
-  isShuttingDown,
-} from "@/lib/worker/shutdown";
-import { ENV_WORKER_PATH, loadWorkerEnvConfig } from "@/services/env.service";
-
 /**
- * Info: (20260130 - Luphia)
- * Worker script to continuously process pending analysis tasks.
- * Run with: npx tsx scripts/workers.run.ts
+ * Info: (20260812 - Luphia) 這個入口已拆成兩個節點，本檔只負責**大聲**告知。
+ *
+ * 拆分理由見 `scripts/run_compute_node.ts` 的檔頭：mission 管線處理使用者上傳的
+ * 內容且不該連資料庫，而 tracker / cron / recorder 的工作就是寫庫。兩者放在同一個
+ * 行程裡，「Executor 沒有資料庫權限」在部署層面就只是一句話。
+ *
+ * ## 為什麼是退出而不是「兩個都跑」
+ *
+ * 讓這支繼續跑兩邊，等於拆分對既有部署完全沒有效果 —— 而那些部署正是隔離最需要
+ * 生效的地方。反過來，讓它只跑其中一半（例如只跑維運）會讓 mission 管線
+ * **靜默停止處理**，那是最糟的一種：沒有錯誤、只有任務不再前進。
+ *
+ * 所以這裡 fail fast：升級後第一次啟動就會看到該改什麼。這是刻意的破壞性變更。
  */
-/**
- * Info: (20260811 - Luphia) 停止條件改讀共用的關機旗標（見 lib/worker/shutdown）。
- *
- * 原本每個迴圈各自 process.on("SIGINT")，13 個迴圈就掛 13 個 listener——
- * 超過 Node 的預設上限會噴 MaxListenersExceededWarning，而且每個迴圈只能管自己，
- * 沒有地方能在關機時統一釋放 mission 執行鎖。
- */
-async function startServiceLoop(
-  name: string,
-  fn: () => Promise<unknown>,
-  intervalMs = 10000,
-) {
-  while (!isShuttingDown()) {
-    try {
-      await fn();
-      await new Promise((resolve) => setTimeout(resolve, intervalMs));
-    } catch (error) {
-      console.error(`[Worker][${name}] Error:`, error);
-      await new Promise((resolve) => setTimeout(resolve, 60000));
-    }
-  }
-}
+const MESSAGE = `
+[Worker] 'npm run worker' has been split into two nodes.
 
-/**
- * Info: (20260812 - Luphia) worker 用自己的 `.env.worker`,不吃系統的 `.env`。
- *
- * 在任何 service 被呼叫之前就載進 `process.env`,理由是 worker 端有不少程式碼
- * 直接讀 `process.env` —— 先載好,它們拿到的就是 worker 自己的設定。
- *
- * **不 fallback 到系統 `.env`**:找不到自己的設定檔就大聲說,而不是悄悄改用
- * web 節點那份。共用會讓一個處理使用者上傳內容的節點看得到 `DATABASE_URL`、
- * `SECRET_VAULT_MASTER_KEY`、`SUPER_ADMIN_*` —— 那些它完全不該擁有。
- *
- * 為什麼缺檔案不直接 `process.exit`:同一個行程裡還有 `TransactionTracker`、
- * `WalletGuardian`、訂閱續約這些**必須**存取資料庫的任務,它們的設定來自別處
- * (見 `known_issues/executor_settings_isolation.md` 的「尚未拆分」一節)。
- * 現在就退出會讓既有部署一升級就整批停擺;所以這裡只大聲記錄,
- * 真正缺鍵的那個任務會在用到時自己失敗。
- */
-async function loadWorkerEnv(): Promise<void> {
-  const config = await loadWorkerEnvConfig();
-  const keys = Object.keys(config);
+  npm run worker:compute   external compute node — mission pipeline (planner /
+                           executor / commitor / closer). Reads .env.worker only.
+                           Must NOT have database access.
 
-  if (keys.length === 0) {
-    console.error(
-      `[Worker] No worker configuration found at ${ENV_WORKER_PATH}. ` +
-        "The worker does not fall back to the system .env — copy .env.worker.example and fill it in.",
-    );
-    return;
-  }
+  npm run worker:ops       internal maintenance node — transaction tracker,
+                           issue pipeline, exchange rate, amortization, wallet
+                           guardian, subscription expiry / renewal. Needs the
+                           database and uses the system .env.
 
-  keys.forEach((key) => {
-    process.env[key] = config[key];
-  });
-  console.log(`[Worker] Loaded ${keys.length} settings from .env.worker`);
-}
+Run both (they are independent processes). ecosystem.config.json already declares
+them as two pm2 apps; if you start the worker by hand, start both.
 
-async function runWorker() {
-  // Info: (20260812 - Luphia) 先載自己的設定，再啟動任何迴圈
-  await loadWorkerEnv();
+Why: documents/architecture/async_workers/00_async_worker_overview.md requires the
+compute node to have no database access — that guarantee only becomes real once the
+database-writing jobs live in a different process.
+`;
 
-  // Info: (20260811 - Luphia) 兩段式中斷 + 結束前釋放 mission 執行鎖
-  installWorkerShutdownHandlers("Worker");
-
-  console.log("[Worker] Starting independent service loops...");
-
-  await Promise.all([
-    startServiceLoop("TransactionTracker", () => scanPendingTransactions()),
-    startServiceLoop("IssueService", () => processIssueNext()),
-    startServiceLoop("MissionPlanner", () => processMissionPlannerNext()),
-    startServiceLoop("MissionExecutor", () => processMissionExecutorNext()),
-    startServiceLoop("MissionCommitor", () => processMissionCommitorNext()),
-    startServiceLoop("MissionCloser", () => processMissionCloserNext()),
-    startServiceLoop("IssueValidator", () => processIssueValidatorNext()),
-    startServiceLoop("IssueRecorder", () => issueRecorderService.processNext()),
-    startServiceLoop(
-      "ExchangeRateSync",
-      () => syncExchangeRates(),
-      8 * 60 * 60 * 1000,
-    ),
-    startServiceLoop(
-      "AmortizationWorker",
-      () => processAmortization(),
-      60 * 60 * 1000,
-    ),
-    // Info: (20260807 - Luphia) 團隊錢包守恆勾稽 + 每日 merkle 錨定（ADR 015 C 案 Phase 1）
-    startServiceLoop(
-      "WalletGuardian",
-      () => runWalletGuardian(),
-      60 * 60 * 1000,
-    ),
-    // Info: (20260807 - Luphia) 訂閱到期降級 / 標記續訂（fail-closed 防線在扣費側即時生效）
-    startServiceLoop(
-      "SubscriptionExpiry",
-      () => expireOverdueTeamSubscriptions(),
-      60 * 60 * 1000,
-    ),
-    // Info: (20260807 - Luphia) autoRenew 自動扣款續訂（逾 3 天寬限期未成即降級 free）
-    startServiceLoop(
-      "SubscriptionRenewal",
-      () => processSubscriptionRenewals(),
-      60 * 60 * 1000,
-    ),
-  ]);
-
-  console.log("[Worker] Stopped.");
-  process.exit(0);
-}
-
-runWorker().catch((err) => {
-  console.error("[Worker] Fatal error:", err);
-  process.exit(1);
-});
+console.error(MESSAGE);
+process.exit(1);

--- a/scripts/run_worker.ts
+++ b/scripts/run_worker.ts
@@ -15,6 +15,7 @@ import {
   installWorkerShutdownHandlers,
   isShuttingDown,
 } from "@/lib/worker/shutdown";
+import { ENV_WORKER_PATH, loadWorkerEnvConfig } from "@/services/env.service";
 
 /**
  * Info: (20260130 - Luphia)
@@ -44,7 +45,44 @@ async function startServiceLoop(
   }
 }
 
+/**
+ * Info: (20260812 - Luphia) worker 用自己的 `.env.worker`,不吃系統的 `.env`。
+ *
+ * 在任何 service 被呼叫之前就載進 `process.env`,理由是 worker 端有不少程式碼
+ * 直接讀 `process.env` —— 先載好,它們拿到的就是 worker 自己的設定。
+ *
+ * **不 fallback 到系統 `.env`**:找不到自己的設定檔就大聲說,而不是悄悄改用
+ * web 節點那份。共用會讓一個處理使用者上傳內容的節點看得到 `DATABASE_URL`、
+ * `SECRET_VAULT_MASTER_KEY`、`SUPER_ADMIN_*` —— 那些它完全不該擁有。
+ *
+ * 為什麼缺檔案不直接 `process.exit`:同一個行程裡還有 `TransactionTracker`、
+ * `WalletGuardian`、訂閱續約這些**必須**存取資料庫的任務,它們的設定來自別處
+ * (見 `known_issues/executor_settings_isolation.md` 的「尚未拆分」一節)。
+ * 現在就退出會讓既有部署一升級就整批停擺;所以這裡只大聲記錄,
+ * 真正缺鍵的那個任務會在用到時自己失敗。
+ */
+async function loadWorkerEnv(): Promise<void> {
+  const config = await loadWorkerEnvConfig();
+  const keys = Object.keys(config);
+
+  if (keys.length === 0) {
+    console.error(
+      `[Worker] No worker configuration found at ${ENV_WORKER_PATH}. ` +
+        "The worker does not fall back to the system .env — copy .env.worker.example and fill it in.",
+    );
+    return;
+  }
+
+  keys.forEach((key) => {
+    process.env[key] = config[key];
+  });
+  console.log(`[Worker] Loaded ${keys.length} settings from .env.worker`);
+}
+
 async function runWorker() {
+  // Info: (20260812 - Luphia) 先載自己的設定，再啟動任何迴圈
+  await loadWorkerEnv();
+
   // Info: (20260811 - Luphia) 兩段式中斷 + 結束前釋放 mission 執行鎖
   installWorkerShutdownHandlers("Worker");
 

--- a/src/__tests__/fx_interceptor.test.ts
+++ b/src/__tests__/fx_interceptor.test.ts
@@ -1,5 +1,7 @@
 import { fxInterceptorService } from "@/services/fx.interceptor.service";
-import { IAggregatedDocumentResult } from "@/skills/utils/document_parser_db_sync";
+// Info: (20260812 - Luphia) `import type` —— 只用到型別；值匯入會把 document_sync.repo → lib/prisma
+// Info: (20260812 - Luphia) 拉進外部運算節點的模組圖（見 voucher.pipeline.orchestrator 的說明）
+import type { IAggregatedDocumentResult } from "@/skills/utils/document_parser_db_sync";
 import { UniversalAccountTag } from "@/constants/enums";
 import { describe, it, expect } from "@jest/globals";
 import { getCrossExchangeRateStatic } from "@/skills/utils/exchange_rate_helper";

--- a/src/__tests__/llm_key_resolution.test.ts
+++ b/src/__tests__/llm_key_resolution.test.ts
@@ -409,6 +409,30 @@ describe("nodes without database access", () => {
   });
 
   /**
+   * Info: (20260812 - Luphia) worker 有自己的設定檔，不吃系統的 `.env`。
+   *
+   * 共用會讓一個處理使用者上傳內容的節點看得到 `DATABASE_URL`、
+   * `SECRET_VAULT_MASTER_KEY`、`SUPER_ADMIN_*` —— 那些它完全不該擁有，
+   * 而持有信任根等於把隔離的意義抵銷掉。
+   *
+   * 斷言原始碼:這個節點只能經 `loadWorkerEnvConfig()` 取設定，
+   * 不得出現讀系統 `.env` / `.env.setup` 的取法（`ENV_PATH`、`ENV_SETUP_PATH`、
+   * `getPriorityEnvConfig`）。
+   */
+  it("should read its own env file and never the system one", () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), ENV_ONLY_FILES[0]),
+      "utf8",
+    );
+    const code = source.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, "");
+
+    expect(code).toContain("loadWorkerEnvConfig(");
+    expect(code).not.toMatch(/\bENV_PATH\b/);
+    expect(code).not.toMatch(/\bENV_SETUP_PATH\b/);
+    expect(code).not.toMatch(/getPriorityEnvConfig/);
+  });
+
+  /**
    * Info: (20260812 - Luphia) 上面兩支驗的是 ChatService **遵守**旗標，
    * 而不是 Executor **有傳**旗標 —— 實測把那個參數拿掉，上面兩支照樣全綠。
    *

--- a/src/__tests__/worker_node_isolation.test.ts
+++ b/src/__tests__/worker_node_isolation.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/**
+ * Info: (20260812 - Luphia) 外部運算節點的資料庫耦合必須是**清單化**的。
+ *
+ * `async_workers/00_async_worker_overview.md` 要求 mission 管線那個節點沒有主資料庫
+ * 權限（那道隔離是防提示詞注入的基礎）。這支測試掃**執行期匯入圖**：從節點入口
+ * 出發，沿著會真正被載入的邊走，看能不能走到 `lib/prisma`。
+ *
+ * 為什麼是匯入圖而不是「有沒有呼叫」：`lib/prisma` 在**載入時**就以
+ * `process.env.DATABASE_URL` 建連線池。只要它在圖裡，那個節點就帶著資料庫用戶端 ——
+ * 「沒有權限」就只剩紀律：連線池在那裡，只是剛好沒人用。
+ *
+ * `import type` 不算邊（編譯後消失）。實際掃出來的結果讓五條「幽靈耦合」現形：
+ * 那些檔案只用到 `document_parser_db_sync` 的型別，卻寫成值匯入，於是把
+ * `document_sync.repo → lib/prisma` 整條拉進圖裡。改成 `import type` 之後就沒了。
+ *
+ * 剩下的一條是**真的**：見 `KNOWN_DB_COUPLING`。
+ */
+const ROOT = process.cwd();
+
+/**
+ * Info: (20260812 - Luphia) 已知且**尚未解決**的耦合，逐條列出而不是整體放行。
+ *
+ * 兩條都是真的（不是匯入寫法的意外），而且是**同一個主題**:
+ * mission 管線需要資料庫裡的**排放係數字典**。
+ *
+ * 1. `voucher.pipeline.orchestrator` → `EmissionFactorRepo.getCoefficientById()`
+ *    （第 124、173 行；`mission.executor.service:521` 會走到）
+ * 2. `skills/document/esg_parsing` → `EmissionFactorRepo.getAllGlobalCoefficients()`
+ *    （第 166 行；經 `skills/index.ts` 被 Executor 取用）
+ *
+ * 也就是說**文件那句「MissionExecutor 絕對沒有存取主資料庫的權限」目前不成立**。
+ * 解法與取捨見 `known_issues/executor_settings_isolation.md`。
+ *
+ * 這個清單的意義是「新增的耦合會變紅，已知的不會讓測試長期紅著」——
+ * 長期紅的測試等於沒有測試。
+ */
+const KNOWN_DB_COUPLING = [
+  "src/repositories/emission_factor.repo.ts",
+  "src/skills/document/esg_parsing.ts",
+];
+
+const resolveModule = (spec: string): string | null => {
+  if (!spec.startsWith("@/")) return null;
+  const base = path.join(ROOT, "src", spec.slice(2));
+  const candidates = [`${base}.ts`, `${base}.tsx`, path.join(base, "index.ts")];
+  return candidates.find((candidate) => fs.existsSync(candidate)) ?? null;
+};
+
+/**
+ * Info: (20260812 - Luphia) 只取執行期會載入的邊。
+ * `import type` / `export type` 編譯後消失；`await import()` 是延遲載入，
+ * 不會把模組帶進啟動時的圖（`chat.service` 正是靠這個把 system_setting 移出圖外）。
+ */
+const runtimeDependencies = (source: string): string[] => {
+  const specs: string[] = [];
+  const pattern =
+    /^\s*(?:import|export)\s+(type\s+)?([\s\S]*?)from\s+"(@\/[^"]+)"/gm;
+  for (const match of source.matchAll(pattern)) {
+    if (match[1]) continue;
+    specs.push(match[3]);
+  }
+  return specs;
+};
+
+/**
+ * Info: (20260812 - Luphia) 蒐集**所有**可達的 prisma 匯入點，不是只找第一條路徑。
+ *
+ * 只回傳第一條路徑的話,新增一條耦合可能被舊路徑遮住 —— 掃描器先找到舊的就停了。
+ * 集合比對與遍歷順序無關,新增任何一個匯入點都會現形。
+ */
+const prismaImportersFrom = (entry: string): string[] => {
+  const found = new Set<string>();
+  const seen = new Set<string>();
+
+  const walk = (file: string): void => {
+    if (seen.has(file)) return;
+    seen.add(file);
+
+    const source = fs.readFileSync(file, "utf8");
+    if (/^\s*import\s+\{[^}]*\}\s+from\s+"@\/lib\/prisma"/m.test(source)) {
+      found.add(path.relative(ROOT, file));
+    }
+
+    for (const spec of runtimeDependencies(source)) {
+      const dependency = resolveModule(spec);
+      if (dependency) walk(dependency);
+    }
+  };
+
+  walk(entry);
+  return [...found].sort();
+};
+
+// Info: (20260812 - Luphia) 去掉註解再比對 —— 註解裡提到檔名不算依賴（這條踩過三次）
+const stripComments = (source: string): string =>
+  source.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, "");
+
+describe("worker node isolation", () => {
+  /**
+   * Info: (20260812 - Luphia) 外部運算節點的圖裡只允許那一條已知耦合。
+   *
+   * 斷言的是**第一步**:從入口走到 prisma 的路徑上，第二個節點必須是清單裡的檔案。
+   * 這樣新增一條完全不同的耦合會變紅，而已知那條不會讓測試長期紅著
+   * （長期紅的測試等於沒有測試）。
+   */
+  it("should not grow new database coupling in the compute node", () => {
+    expect(
+      prismaImportersFrom(path.join(ROOT, "scripts/run_compute_node.ts")),
+    ).toEqual(KNOWN_DB_COUPLING);
+  });
+
+  /**
+   * Info: (20260812 - Luphia) 單一 Executor 入口（`run_executor.ts` 併發啟動的那支）
+   * 必須完全乾淨 —— 它是最貼近文件所述「外部節點」的形態。
+   */
+  it("should keep the single-executor entry free of the database", () => {
+    expect(
+      prismaImportersFrom(path.join(ROOT, "scripts/executor_worker.ts")),
+    ).toEqual([]);
+  });
+
+  /**
+   * Info: (20260812 - Luphia) 反向也釘住:維運節點**應該**碰資料庫。
+   * 若哪天它變乾淨了，代表寫庫的任務被搬走了 —— 那是需要有人知道的事，
+   * 不該是靜默的（訂單追蹤、錢包勾稽、訂閱續約停擺不會有錯誤訊息）。
+   */
+  it("should keep the ops node connected to the database", () => {
+    expect(
+      prismaImportersFrom(path.join(ROOT, "scripts/run_ops_node.ts")).length,
+    ).toBeGreaterThan(0);
+  });
+
+  // Info: (20260812 - Luphia) 節點入口不得互相匯入 —— 拆分若被一行 import 接回去就白拆了
+  it("should keep the two node entries independent", () => {
+    const compute = stripComments(
+      fs.readFileSync(path.join(ROOT, "scripts/run_compute_node.ts"), "utf8"),
+    );
+    const ops = stripComments(
+      fs.readFileSync(path.join(ROOT, "scripts/run_ops_node.ts"), "utf8"),
+    );
+    expect(compute).not.toContain("run_ops_node");
+    expect(ops).not.toContain("run_compute_node");
+  });
+});

--- a/src/lib/worker/service_loop.ts
+++ b/src/lib/worker/service_loop.ts
@@ -1,0 +1,32 @@
+import { isShuttingDown } from "@/lib/worker/shutdown";
+
+/**
+ * Info: (20260812 - Luphia) 常駐迴圈的共用實作。
+ *
+ * 原本住在 `scripts/run_worker.ts` 裡。行程拆成「外部運算節點」與「內部維運節點」
+ * 之後兩邊都要用它 —— 而兩份各自維護一個 `while` 迴圈，遲早會在其中一邊漏掉
+ * 關機旗標或錯誤退避。
+ *
+ * Info: (20260811 - Luphia) 停止條件讀共用的關機旗標（見 lib/worker/shutdown）。
+ *
+ * 原本每個迴圈各自 `process.on("SIGINT")`，13 個迴圈就掛 13 個 listener ——
+ * 超過 Node 的預設上限會噴 MaxListenersExceededWarning，而且每個迴圈只能管自己，
+ * 沒有地方能在關機時統一釋放 mission 執行鎖。
+ */
+export async function startServiceLoop(
+  nodeName: string,
+  name: string,
+  fn: () => Promise<unknown>,
+  intervalMs = 10_000,
+): Promise<void> {
+  while (!isShuttingDown()) {
+    try {
+      await fn();
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    } catch (error) {
+      // Info: (20260812 - Luphia) 帶上節點名 —— 兩個行程的 log 會混在同一個收集器裡
+      console.error(`[${nodeName}][${name}] Error:`, error);
+      await new Promise((resolve) => setTimeout(resolve, 60_000));
+    }
+  }
+}

--- a/src/repositories/document_sync.repo.ts
+++ b/src/repositories/document_sync.repo.ts
@@ -19,7 +19,9 @@ import {
   MeasurementUnit,
 } from "@/constants/enums";
 import { verifyDimensionalConsistency } from "@/constants/dimension";
-import { ISyncDocumentResultParams } from "@/skills/utils/document_parser_db_sync";
+// Info: (20260812 - Luphia) `import type` —— 只用到型別；值匯入會把 document_sync.repo → lib/prisma
+// Info: (20260812 - Luphia) 拉進外部運算節點的模組圖（見 voucher.pipeline.orchestrator 的說明）
+import type { ISyncDocumentResultParams } from "@/skills/utils/document_parser_db_sync";
 import { ACCOUNTS, IAccount } from "@/constants/accounts";
 import { ReconciliationService } from "@/services/reconciliation.service";
 import { MoneyUtil } from "@/lib/utils/money";

--- a/src/services/accounting.engine.service.ts
+++ b/src/services/accounting.engine.service.ts
@@ -1,4 +1,6 @@
-import { IAggregatedDocumentResult } from "@/skills/utils/document_parser_db_sync";
+// Info: (20260812 - Luphia) `import type` —— 只用到型別；值匯入會把 document_sync.repo → lib/prisma
+// Info: (20260812 - Luphia) 拉進外部運算節點的模組圖（見 voucher.pipeline.orchestrator 的說明）
+import type { IAggregatedDocumentResult } from "@/skills/utils/document_parser_db_sync";
 import { Prisma } from "@/generated";
 import { IParsedVoucherLine } from "@/interfaces/voucher";
 import {

--- a/src/services/chat.service.ts
+++ b/src/services/chat.service.ts
@@ -33,7 +33,6 @@ import { CarbonChartTemplateEnum } from "@/constants/carbon_report_charts";
 import { IInventoryExtraction } from "@/types/carbon_chatbot.types";
 import { logger } from "@/lib/utils/logger";
 import { SystemSettingKey } from "@/constants/system_setting";
-import { systemSettingService } from "@/services/system_setting.service";
 
 // Info: (20260714 - Tzuhan) 結構化聊天回覆: readyParagraphId 已通過白名單裁決(非法/none 一律為 null)
 // Info: (20260716 - Tzuhan) #6518:extraction 為已裁決的事實萃取(壞欄位逐筆丟棄),null = 本輪無可萃取
@@ -374,6 +373,24 @@ export class ChatService {
         `${LLM_KEY_MISSING_ERROR_MARKER}: no LLM API key in this node's environment (this node must not read system settings)`,
       );
     }
+
+    /**
+     * Info: (20260812 - Luphia) 動態載入,讓外部運算節點的**匯入圖**裡沒有 prisma。
+     *
+     * 靜態 import 的話,`chat.service → system_setting.service →
+     * system_setting.repo → lib/prisma` 這條鍊會把資料庫用戶端拉進
+     * 外部運算節點的模組圖 —— 而 `lib/prisma` 在載入時就會以
+     * `process.env.DATABASE_URL` 建一個連線池。那個節點依
+     * `async_workers/00_async_worker_overview.md` 不該連得到資料庫,
+     * 於是「沒有權限」就只剩紀律:連線池在那裡,只是剛好沒人用。
+     *
+     * 改成動態之後,只有真的要查設定時才載入。上面兩個早退
+     * (`explicitApiKey`、`!allowSystemSettings`)保證那條路在運算節點上走不到,
+     * 因此 prisma 不會進它的圖 —— `worker_node_isolation.test.ts` 掃匯入圖釘住這件事。
+     */
+    const { systemSettingService } = await import(
+      "@/services/system_setting.service"
+    );
 
     const [settingKey, settingModel] = await Promise.all([
       systemSettingService.get(SystemSettingKey.GEMINI_API_KEY),

--- a/src/services/env.service.ts
+++ b/src/services/env.service.ts
@@ -14,6 +14,26 @@ export const ENV_EXAMPLE_PATH = path.join(
 );
 
 /**
+ * Info: (20260812 - Luphia) worker 節點專屬的設定檔。
+ *
+ * worker 不使用系統的 `.env`,也不讀資料庫 —— 它有自己的一份。三個理由:
+ *
+ * 1. **隔離**:`MissionExecutor` 依 `async_workers/00_async_worker_overview.md`
+ *    沒有主資料庫權限,那道隔離是防提示詞注入的基礎。讓它與 web 節點共用同一份
+ *    `.env`,等於讓它看得到 `DATABASE_URL`、`SECRET_VAULT_MASTER_KEY`、
+ *    `SUPER_ADMIN_*` 這些它完全不該擁有的東西 —— 一個處理使用者上傳內容的節點
+ *    持有信任根,是把隔離的意義抵銷掉。
+ * 2. **最低限度**:worker 只需要它真正用到的鍵（見 `.env.worker.example`）,
+ *    而不是整份 web 設定。
+ * 3. **可獨立部署**:worker 本來就設計成可以放在另一台機器,那時它不會有
+ *    web 節點的 `.env`。給它自己的檔案讓「另一台機器」從特例變成正常情形。
+ */
+export const ENV_WORKER_PATH = path.join(
+  /*turbopackIgnore: true*/ ROOT_PATH,
+  ".env.worker",
+);
+
+/**
  * Info: (20260811 - Luphia) 值必須是單行，否則寫進去就等於憑空多出一個環境變數鍵。
  *
  * .env 是逐行 `KEY=VALUE` 解析的，這個函式又沒有任何 escaping。值裡帶一個換行，
@@ -53,6 +73,17 @@ export async function loadEnvConfig(
     .filter((line) => line.trim() !== "" && !line.trim().startsWith("#"))
     .join("\n");
   return parse(cleanContent);
+}
+
+/**
+ * Info: (20260812 - Luphia) 讀 worker 專屬設定。**不 fallback 到系統 `.env`。**
+ *
+ * 找不到檔案就回空物件 —— 呼叫端據此給出明確的錯誤,而不是悄悄改用 web 的設定。
+ * 「找不到自己的設定就用別人的」正是這條規則要消滅的模糊。
+ */
+export async function loadWorkerEnvConfig(): Promise<Record<string, string>> {
+  if (!fs.existsSync(ENV_WORKER_PATH)) return {};
+  return loadEnvConfig(ENV_WORKER_PATH);
 }
 
 // Info: (20260414 - Luphia) 取得優先的環境變數設定 (先讀取 .env.setup，若無則讀取 .env)

--- a/src/services/fx.interceptor.service.ts
+++ b/src/services/fx.interceptor.service.ts
@@ -1,5 +1,7 @@
 import { UniversalAccountTag } from "@/constants/enums";
-import { IAggregatedDocumentResult } from "@/skills/utils/document_parser_db_sync";
+// Info: (20260812 - Luphia) `import type` —— 只用到型別；值匯入會把 document_sync.repo → lib/prisma
+// Info: (20260812 - Luphia) 拉進外部運算節點的模組圖（見 voucher.pipeline.orchestrator 的說明）
+import type { IAggregatedDocumentResult } from "@/skills/utils/document_parser_db_sync";
 import { getCrossExchangeRateStatic } from "@/skills/utils/exchange_rate_helper";
 import { FIAT_CURRENCIES } from "@/constants/country";
 import { MoneyUtil } from "@/lib/utils/money";

--- a/src/services/mission.executor.service.ts
+++ b/src/services/mission.executor.service.ts
@@ -1,6 +1,6 @@
 import fs from "fs/promises";
 import path from "path";
-import { ENV_PATH, loadEnvConfig } from "@/services/env.service";
+import { loadWorkerEnvConfig } from "@/services/env.service";
 import { ChatService } from "@/services/chat.service";
 import { EsgGenerationSource, CountryCode } from "@/constants/enums";
 import { CurrencyCode } from "@/constants/exchange_rate";
@@ -27,25 +27,24 @@ export async function processNext() {
   console.log("[MissionExecutor] Scanning MISSION_DIR for tasks to execute...");
 
   /**
-   * Info: (20260812 - Luphia) 這個節點的設定只有**一個**來源:`.env` 檔案。
+   * Info: (20260812 - Luphia) 這個節點的設定只有**一個**來源:`.env.worker`。
    *
-   * 專案規則:一個設定只存在 `.env` 或資料庫其中一處,不從多處查找;
-   * `.env` 只保管最低限度(部署環境差異),其餘一律進資料庫。
+   * 專案規則:一個設定只存在一處,不從多處查找;`.env` 只保管最低限度。
+   * 而 worker 更進一步 —— 它有**自己的**設定檔,既不吃系統的 `.env` 也不讀資料庫。
    *
-   * 對這個節點而言,「用哪把 LLM 金鑰」正是部署環境差異 —— 它依
-   * `async_workers/00_async_worker_overview.md` 沒有主資料庫權限,
-   * 所以資料庫那條路對它不存在,`.env` 就是它的單一來源(不是 fallback)。
+   * 為什麼不共用系統 `.env`:那份裡有 `DATABASE_URL`、`SECRET_VAULT_MASTER_KEY`、
+   * `SUPER_ADMIN_*`。`MissionExecutor` 處理的是使用者上傳的憑證內容,
+   * 依 `async_workers/00_async_worker_overview.md` 它連資料庫都不該連得到 ——
+   * 讓它持有信任根,等於把那道隔離的意義抵銷掉。
    *
-   * 刻意不用 `getPriorityEnvConfig()`:那支是「`.env.setup` 優先,否則 `.env`」——
-   * 兩個來源。而 `.env.setup` 是部署精靈的暫存區,簽章後會被清空
-   * (`setup.system_setting` 的 STAGED_KEYS),拿它當來源會在遷移前後給出不同答案。
+   * 為什麼不讀資料庫:同上,那是隔離本身。`allowSystemSettings: false` 讓它成為結構
+   * 而不是「env 剛好有值時才成立」的巧合。
    *
-   * 也刻意不讀 `process.env`:worker 由 `npx tsx scripts/run_worker.ts` 啟動,
-   * 沒有任何地方把 `.env` 載進 `process.env`(`ecosystem.config.json` 只給
-   * `NODE_ENV`),所以那條路在這個節點上幾乎永遠是空的 —— 留著只會讓
-   * 「到底讀到哪一份」變成要試才知道。
+   * 也刻意不讀 `process.env` 之外的檔案（`.env.setup` 是精靈暫存區,簽章後會被清空）——
+   * `run_worker` 啟動時已把 `.env.worker` 載進 `process.env`,這裡直接讀檔是為了讓
+   * 「這個值來自哪個檔案」在這一行就看得出來,不必回頭追進程的啟動流程。
    */
-  const nodeEnv = await loadEnvConfig(ENV_PATH);
+  const nodeEnv = await loadWorkerEnvConfig();
   const missionDirBase = nodeEnv.MISSION_DIR || "missions";
   const missionDirPath = path.join(process.cwd(), missionDirBase);
 
@@ -62,7 +61,7 @@ export async function processNext() {
   const apiKey = nodeEnv.GEMINI_API_KEY;
   if (!apiKey) {
     console.warn(
-      "[MissionExecutor] No LLM API key in this node's environment. Missions that need the LLM will fail loudly; /admin/settings does not reach this node.",
+      "[MissionExecutor] No GEMINI_API_KEY in .env.worker. Missions that need the LLM will fail loudly; this node reads neither the system .env nor the database.",
     );
   }
   /**

--- a/src/services/tax.strategy.service.ts
+++ b/src/services/tax.strategy.service.ts
@@ -1,4 +1,5 @@
-import { IAggregatedDocumentResult } from "@/skills/utils/document_parser_db_sync";
+// Info: (20260812 - Luphia) `import type` —— 只用到型別；理由同 voucher.pipeline.orchestrator
+import type { IAggregatedDocumentResult } from "@/skills/utils/document_parser_db_sync";
 import { UniversalAccountTag, CountryCode } from "@/constants/enums";
 import { MoneyUtil } from "@/lib/utils/money";
 

--- a/src/services/voucher.pipeline.orchestrator.ts
+++ b/src/services/voucher.pipeline.orchestrator.ts
@@ -1,4 +1,12 @@
-import { IAggregatedDocumentResult } from "@/skills/utils/document_parser_db_sync";
+/**
+ * Info: (20260812 - Luphia) `import type` —— 這支只用到型別。
+ *
+ * 寫成值匯入的話，`document_parser_db_sync → document_sync.repo → lib/prisma`
+ * 整條會被拉進外部運算節點的模組圖（Executor 呼叫本檔的 processDbSyncPayload），
+ * 而那個節點依 async_workers/00_async_worker_overview.md 不該連得到資料庫。
+ * 型別在編譯後就消失，執行期本來就沒有這個依賴 —— 只是原本的寫法沒說出來。
+ */
+import type { IAggregatedDocumentResult } from "@/skills/utils/document_parser_db_sync";
 import { CountryCode, NonEmissiveTransactionType } from "@/constants/enums";
 import { TaxStrategyService } from "@/services/tax.strategy.service";
 import { fxInterceptorService } from "@/services/fx.interceptor.service";

--- a/src/services/voucher.pipeline.orchestrator.ts
+++ b/src/services/voucher.pipeline.orchestrator.ts
@@ -121,6 +121,22 @@ export class VoucherPipelineOrchestrator {
 
     // Info: (20260526 - Tzuhan) 2. ESG 稅額自動校正 (ESG Tax Auto-Correction)
     if (fileResult.esg && fileResult.esg.coefficientId) {
+      /**
+       * ToDo: (20260812 - Luphia) 外部運算節點不該連得到主資料庫,這裡是兩處例外之一。
+       *
+       * `mission.executor.service` 會走到本函式,而這一行是**真正的資料庫查詢** ——
+       * 於是 `async_workers/00_async_worker_overview.md` 那句「MissionExecutor 絕對沒有
+       * 存取主系統 PostgreSQL 的權限」目前是目標而非事實。那道隔離是防提示詞注入的基礎:
+       * Executor 處理使用者上傳的憑證內容,即使注入成功也必須穿不過實體網路邊界。
+       *
+       * 另一處在 `skills/document/esg_parsing`（`getAllGlobalCoefficients`）,
+       * 兩者主題相同:管線需要資料庫裡的排放係數字典。
+       *
+       * 三條出路與代價見
+       * `documents/engineering_guidelines/known_issues/executor_settings_isolation.md`:
+       * Planner 預先解析進 mission 檔 / 維運節點提供查詢 API / 給運算節點唯讀係數表權限。
+       * 選定之前 `worker_node_isolation.test.ts` 以清單擋住**新增**的耦合。
+       */
       const coef = await EmissionFactorRepo.getCoefficientById(
         fileResult.esg.coefficientId,
       );
@@ -170,6 +186,7 @@ export class VoucherPipelineOrchestrator {
 
     // Info: (20260526 - Tzuhan) 4. 決定性 ESG 碳排運算 (使用換匯後的金額)
     if (fileResult.esg && fileResult.esg.coefficientId) {
+      // ToDo: (20260812 - Luphia) 同上一處的資料庫例外（見本檔前一個 ToDo 區塊）
       const coef = await EmissionFactorRepo.getCoefficientById(
         fileResult.esg.coefficientId,
       );

--- a/src/skills/document/esg_parsing.ts
+++ b/src/skills/document/esg_parsing.ts
@@ -162,6 +162,17 @@ export class EsgParsingSkill implements ITaskSkill {
       ];
 
       // Info: (20260522 - Tzuhan) Fetch dynamic coefficients from DB (including our Mock EEIOs)
+      /**
+       * ToDo: (20260812 - Luphia) 外部運算節點不該連得到主資料庫,這裡是兩處例外之一。
+       *
+       * 本檔經 `skills/index.ts` 被 `MissionExecutor` 取用,而這一行是真正的資料庫查詢。
+       * `async_workers/00_async_worker_overview.md` 那句「絕對沒有存取主資料庫的權限」
+       * 因此目前是目標而非事實 —— 而那道隔離是防提示詞注入的基礎。
+       *
+       * 另一處在 `voucher.pipeline.orchestrator`（`getCoefficientById`）,
+       * 兩者主題相同:管線需要資料庫裡的排放係數字典。三條出路與代價見
+       * `documents/engineering_guidelines/known_issues/executor_settings_isolation.md`。
+       */
       const dbCoefficients =
         await EmissionFactorRepo.getAllGlobalCoefficients(prisma);
 


### PR DESCRIPTION
### DEVELOP

> **base 是 [#6640](https://github.com/CAFECA-IO/iSunFA/pull/6640) 而不是 develop** —— 這些 commit 原本在那支裡，把它們拆出來是因為 #6640 已經膨脹到 36 檔（主題是 LLM 金鑰解析），混在一起沒人審得動。#6640 已 force-push 回 `280e3bfba`，內容原封不動搬到這裡。

## 為什麼要拆行程

`async_workers/00_async_worker_overview.md` 要求 mission 管線那個節點沒有主資料庫權限 —— 那道隔離是**防提示詞注入的基礎**：Executor 處理使用者上傳的憑證內容，即使注入成功也必須穿不過實體網路邊界。

但拆分之前，同一個行程裡還跑著 `TransactionTracker`、`WalletGuardian`、訂閱續約 —— 那些**必須**連資料庫。於是「Executor 沒有資料庫權限」在程式碼層面只是一句話：行程有連線，Executor 只是剛好沒用。

## 拆法（依逐一驗證過的執行期匯入圖，不是文件敘述）

| 角色 | 啟動 | 內容 | 設定 | 資料庫 |
|---|---|---|---|---|
| 外部運算節點 | `npm run worker:compute` | MissionPlanner / Executor / Commitor / Closer | `.env.worker` | 目標為無 |
| 內部維運節點 | `npm run worker:ops` | TransactionTracker、IssueService、IssueValidator、IssueRecorder、匯率、攤提、錢包勾稽、訂閱到期與續約 | 系統 `.env` | 有 |

四個 mission 迴圈綁在一起，是因為它們是同一個 `MISSION_DIR` 上的檔案狀態機，必須共用檔案系統；維運那九支每一支都碰資料庫。`ecosystem.config.json` 拆成 `isunfa-compute` / `isunfa-ops`，`startServiceLoop` 抽到 `lib/worker/service_loop`。

**`npm run worker` 改成會退出並印出指示**（刻意的破壞性變更）。讓它繼續跑兩邊等於拆分對既有部署完全無效；讓它只跑一半會使 mission 管線**靜默停止** —— 沒有錯誤，只有任務不再前進，那是最糟的一種。

## 順帶清掉五條「幽靈耦合」

掃匯入圖時發現五個檔案只用到 `document_parser_db_sync` 的**型別**卻寫成值匯入，把 `document_sync.repo → lib/prisma` 整條拉進運算節點的模組圖。改成 `import type` 即可 —— 執行期本來就沒有那個依賴，只是原本的寫法沒說出來。`chat.service` 對 `system_setting.service` 的匯入也改為動態（只有真的要查設定時才載入）。

`lib/prisma` 在**載入時**就以 `process.env.DATABASE_URL` 建連線池，所以「在圖裡」本身就是問題 —— 不只是「有沒有呼叫」。

## 剩下兩條是真的：文件那句斷言目前不成立

| 位置 | 呼叫 |
|---|---|
| `voucher.pipeline.orchestrator`（124、173 行） | `EmissionFactorRepo.getCoefficientById()` |
| `skills/document/esg_parsing`（166 行） | `EmissionFactorRepo.getAllGlobalCoefficients()` |

主題相同：**管線需要資料庫裡的排放係數字典**。所以 `00_async_worker_overview.md` 那句「絕對沒有存取主資料庫的權限」目前是**目標而非事實**，而且不是匯入寫法的意外 —— 是兩次真正的查詢。

已在該文件加 ⚠️ 補正、在兩個呼叫點加 `ToDo:`（改到那段程式碼的人不一定會翻文件，而那兩行看起來就是普通查詢 —— 沒有標記的話，下一個人會在旁邊再加第三處），並在 known_issues 記下三條出路：

| 出路 | 代價 |
|---|---|
| Planner 預先把係數解析進 mission 檔 | 真正零資料庫；但係數在排入時凍結，跨日長任務可能用到舊值 |
| 維運節點提供係數查詢 API | 維持隔離（跨界改成 HTTP，符合單向模型）；多一條內部端點與其認證 |
| 給運算節點唯讀係數表權限 | 最省事；但「無資料庫可達性」這個前提消失 |

**那是設計決定，這支 PR 沒有替它選。**

## 測試

`worker_node_isolation.test.ts` 四支：運算節點的 prisma 匯入點必須**等於**已知清單、單一 Executor 入口必須完全乾淨、維運節點**應該**碰資料庫（若哪天變乾淨代表寫庫任務被搬走，那不該是靜默的）、兩個入口不得互相匯入。

兩個自己踩的坑寫在測試註解裡：第一版寫成「只找第一條路徑」，**漏掉了 `esg_parsing` 那條**（舊路徑先被找到就停了），改成蒐集全部可達匯入點才現形；「入口不得互相匯入」那支被自己的註解騙過（`run_ops_node` 註解裡提到 `run_compute_node.ts`），改成去註解後比對。

突變驗證：把 `wallet_audit.cron` 加進運算節點 → 清單那支變紅。

## 一個行為變化要記著

`issue.recorder` 從 `MISSION_DIR/.../execution_log.json` 取 token 計數那段在 `try {} catch {}` 內。兩個節點不共用磁碟後讀不到，計數會落回結果載荷裡的值 —— **盡力而為的行為不變，但數字來源會變**。要精確計數需由運算節點把 log 併入結果載荷。

#### Related Issues

- [X] Issue Number: 從 #6640 拆出

#### Checklist

- [x] Used `@` in import paths.
- [x] Verified naming convention compliance.
- [x] Coding style verification: checked
- [x] new Library: 0
- [x] new Class / Component: 0
- [x] new loop: 0（`startServiceLoop` 是從 `run_worker.ts` 搬出來的既有迴圈）
- [x] new recursive: 1（測試裡的匯入圖遍歷，有 `seen` 集合防環）
- [x] high risk: 1（改變部署入口：`npm run worker` 不再啟動任務）
- [x] new sql: 0

#### UML Diagrams

- None

#### Additional Notes

- 全量 **1412 passed**；`tsc --noEmit` / ESLint / Prettier 乾淨
- 既有的 7 個失敗（`emission_factor_db`、`core_pipeline.e2e`）需實連 Postgres，與 base 相同
- **部署方需要動作**：pm2 用 `ecosystem.config.json` 的話 `pm2 reload` 即可（已宣告兩個 app）；手動啟動的話要改成分別跑 `worker:compute` 與 `worker:ops`，並為運算節點建 `.env.worker`（見 `.env.worker.example`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)