### PR TITLE
fix(chain): 刪掉 ABI 裡合約沒有的宣告（16 條），比對擴到 event

### DIFF
--- a/documents/engineering_guidelines/code_review_checklist.md
+++ b/documents/engineering_guidelines/code_review_checklist.md
@@ -231,7 +231,7 @@ PDF 的文字層修補（把 Chrome 寫成康熙部首的碼位改回漢字）�
 
 `waitForTransactionReceipt` 對 revert 的交易一樣正常回傳收據，只有逾時才拋。因此**每一處都要檢查 `receipt.status`**，並收斂到單一確認函式。
 
-- 更根本的一條：**ABI 宣告的函式不代表部署的合約有**。本 PR 的 `ABIS.CREDIT_POINT` 宣告了 `burn(address, uint256)`，而合約只有 `burnAndUnlock(uint256)`（燒 `msg.sender` 自己的餘額）——那個「收回」從來沒有成功過，而 `receipt.status` 沒被檢查，reverted 交易被回報成成功。
+- 更根本的一條：**ABI 宣告的函式不代表部署的合約有**。本 PR 的 `ABIS.CREDIT_POINT` 宣告了 `burn(address, uint256)`，而合約只有 `burnAndUnlock(uint256)`（燒 `msg.sender` 自己的餘額）——那個「收回」從來沒有成功過，而 `receipt.status` 沒被檢查，reverted 交易被回報成成功。（那些宣告已於後續 PR 刪除，並加了比對測試。）
 - 涉及鏈上能力的功能，去讀 `contracts/*.sol`，不要只讀 ABI。這件事現在有測試守著（`abi_contract_parity.test.ts`：每個 ABI 的函式宣告比對合約原始碼**含繼承鏈**，已知落差登記成只能變短的清單）——寫的時候先確認一件事：**繼承來的函式要解析得到**，否則 `balanceOf` / `transfer` 會被誤判成落差，而「修法」看起來就是把它們一起登記進例外清單，那份清單就成了謊言。
 - 外部呼叫失敗時的補償路徑，要確認它**真的會被觸發**（把成功誤判成功，補償永遠不會執行）。
 

--- a/documents/engineering_guidelines/deploy_checklist_billing_2026q3.md
+++ b/documents/engineering_guidelines/deploy_checklist_billing_2026q3.md
@@ -232,7 +232,7 @@ develop 已併入 attendance/HR 模組（PR #6651，37 個 commit），**8 個�
 | **20260813「物流碳足跡優先扣分配點數」的拍板已不成立** | 逐功能扣款順序（`FEATURE_SPEND_PRIORITY` / `resolveSpendPriority`）於 **2026-08-14 分配上鏈時移除**——分配變成成員的個人資產之後，「先扣分配、後扣額度」這個排序失去意義（先花成員的錢再用團隊額度，沒有情境說得通）。**這與第二層停用無關**：翻回 `isChainCreditSpendable()` 不會讓那個拍板復活，要它復活得重新設計逐功能的扣款順序。產品端需知道該決定目前沒有生效 |
 | ~~遷移腳本是否曾在收據未確認的期間跑過~~ | **已於 2026-08-18 確認沒有殘留資料**（維護者查證），且收據確認已補上，日後不再重現。此列保留為紀錄 |
 | 十餘處鏈上操作仍未確認 `receipt.status` | 集中在 setup、issue、mission、bundler、amortization——不在本 PR 範圍。金流路徑（鑄造、銷毀）已修，其餘以測試的例外清單管理，清單只能變短 |
-| `ABIS.CREDIT_POINT` 與部署的合約不一致 | ABI 宣告了 `burn(address,uint256)`、`forcedTransfer`、`freezePartialTokens`、`setAddressFrozen` 等，合約裡一個都沒有。目前只有 burn 這條路徑實際被呼叫（且已知會失敗），其餘未使用。**這份 ABI 是整條彎路的起點**：它讓「平台可以直接扣成員錢包」看起來成立，於是第二層沒去用旁邊那條已經在跑的持有人簽章路徑。**已於 2026-08-18 加上比對測試**（`abi_contract_parity.test.ts`）：把 `src/config/contracts.ts` 每個 ABI 的函式宣告比對對應的 `contracts/*.sol`（含繼承鏈與 `public` 狀態變數 getter），已知落差登記在 `KNOWN_GAPS` 且清單只能變短。目前登記 16 條落差：CREDIT_POINT 13、SCW 1（`isValidSignature`，Fido2Account 沒實作 ERC-1271）、SCW_FACTORY 2（公司帳戶尚未上鏈）。**修 ABI 本身是另一件事**——刪掉宣告會讓 `token.service` 的 `forcedTransfer()`（無呼叫端）與 `burn()`（已被旗標擋住）失去型別依據，屬清理範圍 |
+| ~~`ABIS.CREDIT_POINT` 與部署的合約不一致~~ | **已於 2026-08-18 修正**（另開 PR，見下）。先前 ABI 宣告了 `burn(address,uint256)`、`forcedTransfer`、`freezePartialTokens`、`setAddressFrozen`、`pause` 等合約一個都沒有的函式；`mint` 也不存在（實際是需要 ISC 抵押的 `collateralizedMint`）。**這份 ABI 是整條彎路的起點**：它讓「平台可以直接扣成員錢包」看起來成立，於是第二層沒去用旁邊那條已經在跑的持有人簽章路徑。現在由 `abi_contract_parity.test.ts` 比對 `src/config/contracts.ts` 與`contracts/*.sol`（含繼承鏈與 `public` 狀態變數 getter，函式與 event 都比），16 條落差已刪除、登記清單為空且只能變長時才需登記。**`token.service` 裡以 inline `parseAbi` 重新宣告那些函式的六支服務函式尚未清理**（`forcedTransfer` / `burn` / `freeze` / `unfreeze` / `pause` / `unpause`，其中五支無呼叫端），列為後續 |
 
 ---
 

--- a/src/__tests__/abi_contract_parity.test.ts
+++ b/src/__tests__/abi_contract_parity.test.ts
@@ -52,40 +52,19 @@ const NO_LOCAL_SOURCE = ["ENTRY_POINT"];
 /**
  * Info: (20260818 - Luphia) 已知落差：ABI 宣告了、合約沒有。每一條都要寫清楚
  * 「實際上有的是什麼」，否則下一個人會再一次以為那個能力存在。
+ *
+ * **目前是空的**——16 條落差已於同日從 ABI 刪除（`CREDIT_POINT` 13、`SCW` 的
+ * `isValidSignature`、`SCW_FACTORY` 的公司帳戶 2 條，另加 `CompanyCreated` 事件）。
+ * 刪掉哪些、為什麼，記在 `src/config/contracts.ts` 各該 ABI 的註解裡。
+ *
+ * 機制保留而不是拿掉：它是**登記**用的，不是「目前有落差」的證明。合約先寫好、ABI
+ * 先進 repo 這種正當的暫時落差，做法是登記在這裡並寫清楚實際上有的是什麼，
+ * 不是把斷言刪掉。
  */
-const KNOWN_GAPS: Record<string, Record<string, string>> = {
-  CREDIT_POINT: {
-    mint: "實際上是 collateralizedMint(address, uint256) payable，鑄造必須提供等比例 ISC 抵押；token.service 的 mint() 呼叫的正是那一支，這條宣告沒有人用",
-    burn: "只有 burnAndUnlock(uint256)，燒的是 msg.sender 自己的餘額。平台無法單方面銷毀成員錢包裡的代幣——而那正是扣費第二層當初走錯的路（見 lib/quota/personal_chain_credits.ts 的更正段）",
-    forcedTransfer:
-      "ERC-3643 樣板的宣告，CreditPoint（ERC20 + AccessControl）沒有實作。token.service 的 forcedTransfer() 以自己的 inline ABI 呼叫它，那支必定 revert——但全 repo 沒有任何呼叫端",
-    freezePartialTokens:
-      "ERC-3643 的部分凍結，CreditPoint 沒有凍結機制，未實作、未使用",
-    unfreezePartialTokens:
-      "解除部分凍結，沒有凍結機制就沒有這支，未實作、未使用",
-    setAddressFrozen: "ERC-3643 的整戶凍結，未實作、未使用",
-    isFrozen: "凍結狀態查詢，沒有凍結機制就沒有這支，未實作、未使用",
-    getFrozenTokens: "凍結數量查詢，未實作、未使用",
-    pause: "CreditPoint 沒有繼承 Pausable，未實作、未使用",
-    unpause: "同 pause，沒有 Pausable 就沒有這支，未實作、未使用",
-    paused: "同 pause，未實作、未使用",
-    compliance: "ERC-3643 的合規模組介面，本專案以 kycRegistry 取代，未實作",
-    identityRegistry:
-      "舊名。合約的公開變數是 kycRegistry；token.service 讀取時以 try/catch 退到這個舊名，是刻意的相容處理",
-  },
-  SCW: {
-    isValidSignature:
-      "Fido2Account 沒有實作 ERC-1271（合約裡與繼承鏈裡都沒有這支），未被呼叫",
-  },
-  SCW_FACTORY: {
-    createCompanyAccount:
-      "部署的 factory 只有個人帳戶（createAccount / getAddress / getAccountByCredentialId），公司帳戶尚未上鏈，未被呼叫",
-    getCompanyAddress: "同 createCompanyAccount，公司帳戶尚未上鏈，未被呼叫",
-  },
-};
+const KNOWN_GAPS: Record<string, Record<string, string>> = {};
 
 /**
- * Info: (20260818 - Luphia) 收集合約**與其繼承鏈**的函式名稱。
+ * Info: (20260818 - Luphia) 收集合約**與其繼承鏈**的函式（或 event）名稱。
  *
  * 一定要走繼承鏈：`CreditPoint is ERC20, AccessControl`，`balanceOf` / `transfer` /
  * `decimals` 都來自 vendored 的 OpenZeppelin（`contracts/lib/@openzeppelin/`），
@@ -94,8 +73,9 @@ const KNOWN_GAPS: Record<string, Record<string, string>> = {
  * 也收 `public` 狀態變數：Solidity 會為它們產生同名的 getter（例如
  * `kycRegistry`、`collateralRate`），那些在 ABI 裡看起來就是函式。
  */
-function collectFunctionNames(
+function collectNames(
   solPath: string,
+  kind: "function" | "event",
   seen = new Set<string>(),
   found = new Set<string>(),
 ): Set<string> {
@@ -103,26 +83,36 @@ function collectFunctionNames(
   if (seen.has(absolute) || !existsSync(absolute)) return found;
   seen.add(absolute);
 
-  // Info: (20260818 - Luphia) 先去掉行註解，免得被註解掉的函式簽章算進來
+  // Info: (20260818 - Luphia) 先去掉行註解，免得被註解掉的簽章算進來
   const source = readFileSync(absolute, "utf8").replace(/\/\/[^\n]*/g, "");
 
-  for (const match of source.matchAll(/function\s+([A-Za-z_]\w*)\s*\(/g)) {
-    found.add(match[1]);
-  }
   for (const match of source.matchAll(
-    /^\s*[\w.[\]]+(?:\s+\w+)?\s+public\s+(?:constant\s+|immutable\s+)?([A-Za-z_]\w*)\s*[;=]/gm,
+    new RegExp(`${kind}\\s+([A-Za-z_]\\w*)\\s*\\(`, "g"),
   )) {
     found.add(match[1]);
+  }
+
+  /**
+   * Info: (20260818 - Luphia) `public` 狀態變數會產生同名 getter（`kycRegistry`、
+   * `collateralRate`），在 ABI 裡看起來就是函式。event 沒有這回事。
+   */
+  if (kind === "function") {
+    for (const match of source.matchAll(
+      /^\s*[\w.[\]]+(?:\s+\w+)?\s+public\s+(?:constant\s+|immutable\s+)?([A-Za-z_]\w*)\s*[;=]/gm,
+    )) {
+      found.add(match[1]);
+    }
   }
 
   for (const match of source.matchAll(
     /import\s*(?:\{[^}]*\}\s*from\s*)?["']([^"']+)["']/g,
   )) {
     const target = match[1];
-    collectFunctionNames(
+    collectNames(
       target.startsWith(".")
         ? resolve(dirname(absolute), target)
         : join(CONTRACTS_DIR, target),
+      kind,
       seen,
       found,
     );
@@ -130,6 +120,9 @@ function collectFunctionNames(
 
   return found;
 }
+
+const collectFunctionNames = (solPath: string): Set<string> =>
+  collectNames(solPath, "function");
 
 function declaredFunctionNames(abi: Abi): string[] {
   return abi
@@ -186,27 +179,48 @@ describe("ABI 宣告與部署合約的一致性", () => {
     },
   );
 
-  /**
-   * Info: (20260818 - Luphia) 清單只能變短：登記的落差若其實存在，就必須從清單移除。
-   *
-   * 這條的用途是**合約補上函式的那一天**。上面那條 `toEqual` 已經涵蓋了同一件事，
-   * 但失敗訊息只會顯示兩個陣列不同；這裡逐名比對，紅的時候直接指出是哪一支。
-   */
-  it.each(
-    Object.entries(KNOWN_GAPS).flatMap(([abiKey, gaps]) =>
-      Object.keys(gaps).map((name) => [abiKey, name] as const),
-    ),
-  )("%s.%s 仍然不存在於合約（存在了就該從清單移除）", (abiKey, name) => {
-    const actual = collectFunctionNames(
-      join(CONTRACTS_DIR, ABI_SOURCES[abiKey]),
-    );
+  it.each(Object.keys(ABI_SOURCES))(
+    "%s：宣告的 event 都存在於合約（含繼承）",
+    (abiKey) => {
+      const actual = collectNames(
+        join(CONTRACTS_DIR, ABI_SOURCES[abiKey]),
+        "event",
+      );
+      const declared = ABIS[abiKey as keyof typeof ABIS]
+        .filter((item) => item.type === "event")
+        .map((item) => item.name);
 
-    expect(actual.has(name)).toBe(false);
+      expect(declared.filter((name) => !actual.has(name))).toEqual([]);
+    },
+  );
+
+  /**
+   * Info: (20260818 - Luphia) 以下三條守 `KNOWN_GAPS` 的紀律。目前清單是空的，
+   * 所以它們現在等於「清單維持空的」——用 `it` 迴圈而不是 `it.each`，
+   * 因為 `it.each([])` 在 Jest 會直接丟錯。
+   *
+   * 清單只能變短：登記的落差若其實存在，就必須從清單移除。上面那條 `toEqual`
+   * 已經涵蓋同一件事，但失敗訊息只顯示兩個陣列不同；這裡逐名比對，紅的時候
+   * 直接指出是哪一支。
+   */
+  it("登記的落差仍然不存在於合約（存在了就該從清單移除）", () => {
+    for (const [abiKey, gaps] of Object.entries(KNOWN_GAPS)) {
+      const actual = collectFunctionNames(
+        join(CONTRACTS_DIR, ABI_SOURCES[abiKey]),
+      );
+
+      for (const name of Object.keys(gaps)) {
+        expect({ abiKey, name, existsInContract: actual.has(name) }).toEqual({
+          abiKey,
+          name,
+          existsInContract: false,
+        });
+      }
+    }
   });
 
-  it.each(Object.keys(KNOWN_GAPS))(
-    "%s：登記的落差都真的出現在 ABI 裡（不留腐爛條目）",
-    (abiKey) => {
+  it("登記的落差都真的出現在 ABI 裡（不留腐爛條目）", () => {
+    for (const abiKey of Object.keys(KNOWN_GAPS)) {
       const declared = declaredFunctionNames(
         ABIS[abiKey as keyof typeof ABIS] as Abi,
       );
@@ -214,8 +228,8 @@ describe("ABI 宣告與部署合約的一致性", () => {
       for (const name of registeredGaps(abiKey)) {
         expect(declared).toContain(name);
       }
-    },
-  );
+    }
+  });
 
   it("每條登記的落差都寫了「實際上有的是什麼」", () => {
     for (const [abiKey, gaps] of Object.entries(KNOWN_GAPS)) {

--- a/src/__tests__/chain_receipt_status.test.ts
+++ b/src/__tests__/chain_receipt_status.test.ts
@@ -135,8 +135,9 @@ describe("收回分配點數已停用", () => {
  * Info: (20260818 - Luphia) 平台無權單方面銷毀成員錢包裡的代幣（調查 20260818）。
  *
  * `CreditPoint` 只有 `burnAndUnlock(uint256)`，燒的是 `msg.sender` 自己的餘額；
- * 沒有 `burn(address, uint256)`，而 `ABIS.CREDIT_POINT` 卻宣告了那個函式——
- * ABI 與部署的合約不一致，那正是 `chargeChainCredits` 當初看起來合理的原因。
+ * 沒有 `burn(address, uint256)`。`ABIS.CREDIT_POINT` 曾經宣告過那個函式，那正是
+ * `chargeChainCredits` 當初看起來合理的原因；該宣告已刪除，並由
+ * `abi_contract_parity.test.ts` 擋下同一類新增。
  *
  * 這一條釘住的是**平台權限的邊界**，不是「扣個人點數做不到」：扣款由持有人簽章
  * 就做得到，產品裡已經在用（`ensurePersonalCreditCharge` 的兩段式訂單 → 成員錢包

--- a/src/config/contracts.ts
+++ b/src/config/contracts.ts
@@ -37,15 +37,22 @@ export const ABIS = {
     "event AccountCreated(address indexed scw, uint256 pubKeyX, uint256 pubKeyY, uint256 salt, string credentialId, string username, string imageUrl)",
     "function getAddress(bytes calldata credentialId, uint256 pubKeyX, uint256 pubKeyY, uint256 salt) public view returns (address)",
     "function createAccount(bytes calldata credentialId, uint256 pubKeyX, uint256 pubKeyY, uint256 salt, string calldata username, string calldata imageUrl) external returns (address)",
-    "event CompanyCreated(address indexed scw, uint256[][] owners, uint256 threshold, uint256 salt, string name, string imageUrl)",
-    "function createCompanyAccount(uint256[][] owners, uint256 threshold, uint256 salt, string name, string imageUrl) external returns (address)",
-    "function getCompanyAddress(uint256[][] owners, uint256 threshold, uint256 salt) public view returns (address)",
+    /**
+     * Info: (20260818 - Luphia) 刪掉公司帳戶的三條宣告（`createCompanyAccount`、
+     * `getCompanyAddress`、`CompanyCreated` 事件）：部署的 `Fido2AccountFactory` 只有
+     * 個人帳戶（`createAccount` / `getAddress` / `getAccountByCredentialId`），
+     * 公司帳戶尚未上鏈。全 repo 沒有任何呼叫端。
+     */
   ]),
 
-  // Info: (20251230 - Tzuhan) Smart Contract Wallet (Personal/Company)
+  /**
+   * Info: (20251230 - Tzuhan) Smart Contract Wallet (Personal/Company)
+   *
+   * Info: (20260818 - Luphia) 刪掉 `isValidSignature`：`Fido2Account` 沒有實作 ERC-1271
+   * （合約與繼承鏈裡都沒有這支），沒有呼叫端。要支援 ERC-1271 得先改合約。
+   */
   SCW: parseAbi([
     "function execute(address dest, uint256 value, bytes func) external",
-    "function isValidSignature(bytes32 hash, bytes memory signature) public view returns (bytes4)",
   ]),
 
   // Info: (20260418 - Luphia) Evolved RWA Identity Registry & NFT Card
@@ -59,27 +66,33 @@ export const ABIS = {
     "function updateExperience(uint256 tokenId, uint256 addedExp) external",
   ]),
 
-  // Info: (20251230 - Tzuhan) Credit Point Token
+  /**
+   * Info: (20251230 - Tzuhan) Credit Point Token
+   *
+   * Info: (20260818 - Luphia) 刪掉 13 條 `CreditPoint` 沒有的宣告（ERC-3643 樣板抄來的
+   * `burn(address,uint256)` / `forcedTransfer` / 凍結 / pause / `compliance` 等，以及
+   * `mint`——實際上是需要 ISC 抵押的 `collateralizedMint`）。
+   *
+   * 那份宣告不是無害的文件誤差：它讓「平台可以直接扣成員錢包」看起來成立，扣費第二層
+   * 因此走了平台側 burn，而 viem 只在**送出交易時**才失敗。連帶的錯誤診斷（「合約層面
+   * 做不到、要改合約」）抄進了六個檔案與五份文件，見 `lib/quota/personal_chain_credits.ts`
+   * 的更正段。`abi_contract_parity.test.ts` 現在會擋下同一類新增。
+   *
+   * 補上四條**合約真的有、而且程式已經在用**的：先前這些散落在各處的 inline `parseAbi`
+   * 裡重新宣告一次（`token.service` 的 `collateralizedMint` / `kycRegistry`、
+   * `user_op_builder` 的 `transfer`），而重新宣告正是繞過這份 ABI 的做法。
+   */
   CREDIT_POINT: parseAbi([
-    "function mint(address to, uint256 amount) external",
+    "function collateralizedMint(address to, uint256 amount) external payable",
+    "function burnAndUnlock(uint256 amount) external",
     "function setKYCRegistry(address _kycRegistry) external",
-    "function burn(address userAddress, uint256 amount) external",
-    "function forcedTransfer(address from, address to, uint256 amount) external returns (bool)",
-    "function freezePartialTokens(address userAddress, uint256 amount) external",
-    "function unfreezePartialTokens(address userAddress, uint256 amount) external",
-    "function setAddressFrozen(address userAddress, bool freeze) external",
-    "function isFrozen(address userAddress) external view returns (bool)",
-    "function getFrozenTokens(address userAddress) external view returns (uint256)",
-    "function pause() external",
-    "function unpause() external",
-    "function paused() external view returns (bool)",
+    "function kycRegistry() external view returns (address)",
+    "function transfer(address to, uint256 amount) external returns (bool)",
     "function balanceOf(address account) view returns (uint256)",
     "function decimals() view returns (uint8)",
     "function name() view returns (string)",
     "function symbol() view returns (string)",
     "function totalSupply() view returns (uint256)",
-    "function compliance() external view returns (address)",
-    "function identityRegistry() external view returns (address)",
   ]),
 
   // Info: (20260807 - Luphia) 每日 Ledger merkle 錨定（ADR 015 C 案 Phase 1）

--- a/src/lib/quota/personal_chain_credits.ts
+++ b/src/lib/quota/personal_chain_credits.ts
@@ -26,7 +26,9 @@ export function isChainCreditConfigured(): boolean {
  *
  * `chargeChainCredits` 走的是平台側 burn：代理帳號直接呼叫合約把成員錢包裡的代幣
  * 銷毀。`CreditPoint` 沒有那個函式（只有 `burnAndUnlock(uint256)`，燒 `msg.sender`
- * 自己的餘額），而 `ABIS.CREDIT_POINT` 卻宣告了它——所以這條扣款從來沒有成功過。
+ * 自己的餘額），而 `ABIS.CREDIT_POINT` 曾經宣告過它——所以這條扣款從來沒有成功過。
+ * 那條宣告已刪除（見 `config/contracts.ts`），`abi_contract_parity.test.ts` 會擋下
+ * 同一類新增。
  *
  * 在此之前的行為是 fail-**open**：`spendCredits` 把鏈上餘額加進 `available` 當作
  * 放行依據，而扣款必定失敗、餘額永遠不會減少——於是一個持有 ≥1 點的成員可以


### PR DESCRIPTION
### DEVELOP

- [X] Description: 刪掉 `src/config/contracts.ts` 裡**部署合約其實沒有的 16 條宣告**，並把 `abi_contract_parity.test.ts` 的比對從 function 擴到 event。

那份 ABI 不是無害的文件誤差：它宣告了 `burn(address, uint256)`，而 `CreditPoint` 只有 `burnAndUnlock(uint256)`（燒 `msg.sender` 自己的餘額）。於是「平台可以直接扣成員錢包」看起來成立，扣費第二層照著走，而 viem 只在**送出交易時**才失敗（且在 `receipt.status` 的檢查補上之前，那筆 revert 還被回報成成功）。連帶的錯誤診斷「合約層面做不到、要改合約」抄進了六個檔案與五份文件 —— 實際上扣個人點數以持有人簽章一直做得到，其他功能都在用。

刪掉的宣告：

| ABI | 刪掉 |
|---|---|
| `CREDIT_POINT`（13 條） | `mint`（實際是需 ISC 抵押的 `collateralizedMint`）、`burn`、`forcedTransfer`、`freezePartialTokens`、`unfreezePartialTokens`、`setAddressFrozen`、`isFrozen`、`getFrozenTokens`、`pause`、`unpause`、`paused`、`compliance`（以上皆 ERC-3643 樣板抄來、未實作）、`identityRegistry`（舊名） |
| `SCW`（1 條） | `isValidSignature` —— `Fido2Account` 沒有實作 ERC-1271，合約與繼承鏈裡都沒有這支 |
| `SCW_FACTORY`（2 條 + 1 event） | `createCompanyAccount`、`getCompanyAddress`、`CompanyCreated` —— 部署的 factory 只有個人帳戶 |

同時**補上四條合約真的有、而且程式已經在用**的：`collateralizedMint`、`burnAndUnlock`、`kycRegistry`、`transfer`。這些先前散落在各處的 inline `parseAbi` 裡重新宣告一次，而重新宣告正是繞過這份 ABI 的做法。

`KNOWN_GAPS` 因此清空，但**機制保留**：它是**登記**落差用的，不是「目前有落差」的證明。合約先寫好、ABI 先進 repo 這種正當的暫時落差，做法是登記並寫清楚「實際上有的是什麼」。

#### Related Issues

- [X] Issue Number: 無對應 issue。脈絡：#6652（比對測試在該 PR 加入，已併入 develop）、#6681（同一份 ABI 導致的守恆凍結為另一條線）

#### Checklist

- [x] Used `@` in import paths.
- [x] Verified naming convention compliance ([Naming Convention Guidelines](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md)).
- [x] Coding style verification: checked（`typecheck` / `lint` 皆綠）
- [x] new Library: 0
- [x] new Class / Component: 0
- [x] new loop: 4 —— 全部在測試檔內，皆為有界的 `for...of`（繼承鏈的 function／event 收集、`KNOWN_GAPS` 逐條檢查）。**生產程式碼 0**
- [x] new recursive: 1 —— 測試檔的 `collectNames()` 沿 Solidity `import` 走繼承鏈，以 `seen` 集合去重，因此對循環 import 也會終止；深度受 `contracts/` 的檔案數限制
- [x] high risk: 0 —— 刪掉的宣告經逐一確認**無任何生產呼叫端**（`token.service` 的 `forcedTransfer` / `burn` 等使用各自的 inline `parseAbi`，不經這份 ABI；`burn` 那條路徑另已被 `isChainCreditSpendable()` 擋住）。`tsc` 乾淨即證明沒有型別層的呼叫端
- [x] new sql: 0

#### UML Diagrams

- None

#### Additional Notes

- 比對擴到 **event** 之後才抓到 `CompanyCreated`（原本只比 function）。function 與 event 共用同一支繼承鏈收集器，`public` 狀態變數的自動 getter 只在 function 模式收集。
- 測試保有一條**正向**斷言證明繼承鏈真的解析到了（`balanceOf` / `transfer` / `hasRole` / `kycRegistry` 都要找得到）。少了它，哪天 import 寫法變了、繼承鏈解析不到，落差清單會暴增，而「修法」看起來就是把 `balanceOf` 一起登記進例外清單 —— 那份清單就成了謊言。
- **mutation 實跑**：加回 `burn` 宣告 → 1 紅；加回 `CompanyCreated` event → 1 紅。
- **尚未清理**：`token.service` 有六支服務函式以 inline `parseAbi` 呼叫這些不存在的函式（`forcedTransfer` / `burn` / `freeze` / `unfreeze` / `pause` / `unpause`，其中五支無呼叫端）。刪掉它們是行為面的清理，不該夾在 ABI 修正裡 —— 已列在部署檢查表。
- 測試結果：`npm run test` 198 suites / 2493 passed、`test:no-dotenv` 同樣 2493、`test:tz` 55、`tsc --noEmit` 乾淨。
- 無 schema 變更、無回填、無環境變數變更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
