### PR TITLE
fix(logistics): 四處字串改走 i18n，限制摘要在 ja / ko / zh_cn 改為英文回退

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isunfa",
-  "version": "0.12.0+215",
+  "version": "0.12.0+216",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/__tests__/logistics_guide.test.ts
+++ b/src/__tests__/logistics_guide.test.ts
@@ -209,15 +209,39 @@ describe("語言檔的操作說明", () => {
  * Info: (20260820 - Luphia) 限制摘要是原本頁尾折疊區真正想達成的事:
  * 看到數字的人同時看到數字的邊界。固化其規模,避免日後被當成裝飾刪掉。
  */
+const highlightsOf = (dictionary: {
+  methodology?: { highlights?: string[] };
+}): string[] => dictionary.methodology?.highlights ?? [];
+
+/**
+ * Info: (20260820 - Luphia) ja / ko / zh_cn 的限制摘要刻意維持英文回退,
+ * 與同一區塊的 sections 一致 —— 審計用詞的準確度無法自行驗證,
+ * 而譯錯的限制摘要比英文原文更危險:讀者會以為自己讀懂了。
+ */
+const FALLBACK_LOCALES = ["ja", "ko", "zh_cn"] as const;
+
 describe("報告旁的限制摘要", () => {
   it.each(LOCALES)("%s 有三條限制摘要", (_locale, dictionary) => {
-    const highlights = (
-      dictionary as { methodology?: { highlights?: string[] } }
-    ).methodology?.highlights;
-    expect(highlights?.length ?? 0).toBeGreaterThanOrEqual(3);
-    expect(highlights?.length).toBe(
-      (zhTw as { methodology?: { highlights?: string[] } }).methodology
-        ?.highlights?.length,
-    );
+    expect(highlightsOf(dictionary).length).toBeGreaterThanOrEqual(3);
+    expect(highlightsOf(dictionary).length).toBe(highlightsOf(zhTw).length);
+  });
+
+  /**
+   * Info: (20260820 - Luphia) 回退語言必須與 en **逐字相同**。
+   *
+   * 沒有這條斷言,英文文案更新後三份回退會靜默留在舊版 ——
+   * 而回退的內容既然是英文,任何差異就只可能是漏同步,不可能是翻譯。
+   * 這也是「翻譯落地」的驗收點:某語言不再等於 en,即代表它已翻譯,
+   * 屆時應同步移除該語言檔 highlights 上方的回退註解。
+   */
+  it.each(
+    LOCALES.filter(([locale]) => FALLBACK_LOCALES.includes(locale as never)),
+  )("%s 的限制摘要與 en 的英文回退逐字相同", (_locale, dictionary) => {
+    expect(highlightsOf(dictionary)).toEqual(highlightsOf(en));
+  });
+
+  // Info: (20260820 - Luphia) zh_tw 是來源語言,必須是中文而非回退
+  it("zh_tw 的限制摘要不是英文回退", () => {
+    expect(highlightsOf(zhTw)).not.toEqual(highlightsOf(en));
   });
 });

--- a/src/app/(landing)/transportation_carbon_footprint_calculator/page.tsx
+++ b/src/app/(landing)/transportation_carbon_footprint_calculator/page.tsx
@@ -82,7 +82,7 @@ import {
   type ILegacyBatchItem,
 } from "@/lib/utils/logistics_report";
 import { IOrderPayload } from "@/hooks/use_order_transaction";
-import { ANALYSIS_CATEGORY } from "@/constants/analysis";
+import { ANALYSIS_CATEGORY, MILEAGE_ACTION } from "@/constants/analysis";
 import {
   TRANSPORT_CALCULATOR_QUERY_PARAM,
   TRANSPORT_CALCULATOR_TAB,
@@ -386,7 +386,9 @@ function ReportPageContent() {
 
     if (!hasManualParams) {
       if (!aiInput.trim()) {
-        setError("請輸入運輸路線描述，或展開進階設定手動輸入完整參數。");
+        setError(
+          t("transportation_carbon_footprint_calculator.error.missing_input"),
+        );
         return;
       }
       setLoading(true);
@@ -407,7 +409,9 @@ function ReportPageContent() {
           throw new Error(
             errorData.message ||
               errorData.error ||
-              `AI 解析失敗 (${resParse.status})`,
+              `${t(
+                "transportation_carbon_footprint_calculator.error.ai_parse_failed",
+              )} (${resParse.status})`,
           );
         }
 
@@ -423,7 +427,13 @@ function ReportPageContent() {
         setWeightKg(currentWeight);
         setShowManual(true);
       } catch (err) {
-        setError(err instanceof Error ? err.message : "AI 解析失敗");
+        setError(
+          err instanceof Error
+            ? err.message
+            : t(
+                "transportation_carbon_footprint_calculator.error.ai_parse_failed",
+              ),
+        );
         setLoading(false);
         setIsParsing(false);
         return;
@@ -440,7 +450,9 @@ function ReportPageContent() {
       currentDest.lng === "" ||
       currentWeight === ""
     ) {
-      setError("無法取得完整參數，請確認 AI 解析結果或手動輸入。");
+      setError(
+        t("transportation_carbon_footprint_calculator.error.missing_params"),
+      );
       return;
     }
 
@@ -1258,13 +1270,23 @@ function ReportPageContent() {
         }
       } catch (err) {
         console.error("Failed to load history", err);
-        setError("無法載入歷史報告");
+        setError(
+          t(
+            "transportation_carbon_footprint_calculator.error.load_history_failed",
+          ),
+        );
       } finally {
         setLoading(false);
       }
       return false;
     },
-    [setActiveTab],
+    /**
+     * Info: (20260820 - Luphia) t 進入依賴陣列不會讓 handleLoadHistory 變得不穩定:
+     * I18nProvider 位於 root layout,其 state 只在切換語言時變動,
+     * 故 t 的識別在同一語言下是穩定的 —— 依賴 handleLoadHistory 的
+     * analysisId 自動載入 effect 不會因此每次 render 都重跑。
+     */
+    [setActiveTab, t],
   );
 
   // Info: (20260724 - Tzuhan) URL 帶 analysisId 時自動載入該筆(刷新/前進可重現載入的報告檢視,需求四)
@@ -1317,9 +1339,16 @@ function ReportPageContent() {
     {
       key: "type",
       label: t("common.type"),
+      /**
+       * Info: (20260820 - Luphia) 沿用分頁標籤的鍵而不新增兩個鍵:
+       * 這一欄回答的正是「這筆載入後會切到哪個分頁」,兩處必須是同一個詞 ——
+       * 分開定義就會出現「清單寫 A、分頁寫 B」而沒有任何機制會發現。
+       */
       render: (row) => (
         <span className="font-bold text-gray-700">
-          {row.action === "calculate_batch" ? "里程核算" : "碳排核算"}
+          {row.action === MILEAGE_ACTION.CALCULATE_BATCH
+            ? t("transportation_carbon_footprint_calculator.ui.tab_mileage")
+            : t("transportation_carbon_footprint_calculator.ui.tab_analysis")}
         </span>
       ),
     },
@@ -1327,7 +1356,7 @@ function ReportPageContent() {
       key: "origin",
       label: t("common.origin"),
       render: (row) => {
-        if (row.action === "calculate_batch") {
+        if (row.action === MILEAGE_ACTION.CALCULATE_BATCH) {
           if (row.items && row.items.length === 1) {
             return (
               <div className="flex items-center gap-1.5 text-sm text-gray-700">
@@ -1367,7 +1396,7 @@ function ReportPageContent() {
       key: "dest",
       label: t("common.destination"),
       render: (row) => {
-        if (row.action === "calculate_batch") {
+        if (row.action === MILEAGE_ACTION.CALCULATE_BATCH) {
           if (row.items && row.items.length === 1) {
             return (
               <div className="flex items-center gap-1.5 text-sm text-gray-700">
@@ -1827,13 +1856,13 @@ function ReportPageContent() {
                       expandedKeys={historyExpandedKeys}
                       onExpandedKeysChange={setHistoryExpandedKeys}
                       rowExpandable={(row) =>
-                        row.action === "calculate_batch" &&
+                        row.action === MILEAGE_ACTION.CALCULATE_BATCH &&
                         row.items !== undefined &&
                         row.items.length > 1
                       }
                       expandedRowRender={(row) => {
                         if (
-                          row.action !== "calculate_batch" ||
+                          row.action !== MILEAGE_ACTION.CALCULATE_BATCH ||
                           !row.items ||
                           row.items.length <= 1
                         )

--- a/src/i18n/locales/en/transportation_carbon_footprint_calculator.ts
+++ b/src/i18n/locales/en/transportation_carbon_footprint_calculator.ts
@@ -174,9 +174,9 @@ export const transportationCarbonFootprintCalculator = {
     limits_title: "Read this before using these numbers",
     read_full: "Read the full calculation method",
     highlights: [
-      "The scope covers **transport only**: no warehousing, handling or packaging, and nothing from the production or disposal of the goods themselves. This number is not a full product life-cycle carbon footprint.",
-      "The road network **currently covers Taiwan only**: land legs elsewhere are estimated as great-circle distance x {{landTortuosity}} and marked Estimated in the report. Where a route is mostly non-Taiwan land transport, that estimation error goes straight into the result.",
-      "The sea and air factors were **produced for the United States** (published 2016 and 2017), and the air distance excludes routing detours and high-altitude radiative forcing, so the real impact is higher than the figure reported here.",
+      "The scope covers **transport only**: no warehousing, loading and unloading, or packaging, and nothing from the production or disposal of the goods themselves. The result is therefore not the full life-cycle carbon footprint of the shipment.",
+      "The road network **currently covers Taiwan only**: road legs outside Taiwan are estimated from straight-line distance times a tortuosity factor of {{landTortuosity}} and marked Estimated in the report. Where a route's emissions are dominated by road transport abroad, the estimation error enters the result directly.",
+      "The sea and air factors have a **production region of the United States** (announced 2016 and 2017), and the air distance excludes routing detours, climb and high-altitude radiative forcing — both the actual flight distance and the climate impact exceed the figures reported here.",
     ],
     sections: [
       {

--- a/src/i18n/locales/en/transportation_carbon_footprint_calculator.ts
+++ b/src/i18n/locales/en/transportation_carbon_footprint_calculator.ts
@@ -11,6 +11,8 @@ export const transportationCarbonFootprintCalculator = {
     ai_parse_failed: "AI parsing failed",
     missing_params:
       "Unable to obtain complete parameters. Please confirm the AI parsing results or enter them manually.",
+    load_history_failed:
+      "Unable to load the historical report. Please try again later.",
   },
   payment: {
     fee_name: "Carbon Footprint Analysis Fee",

--- a/src/i18n/locales/ja/transportation_carbon_footprint_calculator.ts
+++ b/src/i18n/locales/ja/transportation_carbon_footprint_calculator.ts
@@ -173,10 +173,12 @@ export const transportationCarbonFootprintCalculator = {
       "以下の各節で、それぞれの数値がどこから来ているかを説明します。結論をどこまで信頼できるかだけを知りたい場合は、第 11 節「既知の制約」へ直接お進みください。",
     limits_title: "この数値を使う前に必ずお読みください",
     read_full: "算出方法の全文を読む",
+    // Info: (20260820 - Luphia) 限制摘要同 sections 以英文回退：日文審計用詞我無法驗證準確度，
+    // Info: (20260820 - Luphia) 譯錯的限制摘要比沒有摘要更糟。用詞與 sections 一致，翻譯可一併替換。
     highlights: [
-      "算定範囲は**輸送プロセスのみ**です。倉庫保管・荷役・包装は含まず、貨物自体の生産や廃棄も含みません。この数値は製品のライフサイクル全体のカーボンフットプリントではありません。",
-      "道路ネットワークは**現在台湾のみを収録**しています。台湾外の陸上区間は大圏距離 × {{landTortuosity}} で推定し、レポートでは「概算値」と表示されます。台湾外の陸送が主となるルートでは、その推定誤差がそのまま結果に入ります。",
-      "海上と航空の係数は**生産地域が米国**（公表年 2016 年と 2017 年）であり、航空距離は迂回飛行と高高度の放射強制力を含まないため、実際の影響は本レポートの数値より大きくなります。",
+      "The scope covers **transport only**: no warehousing, loading and unloading, or packaging, and nothing from the production or disposal of the goods themselves. The result is therefore not the full life-cycle carbon footprint of the shipment.",
+      "The road network **currently covers Taiwan only**: road legs outside Taiwan are estimated from straight-line distance times a tortuosity factor of {{landTortuosity}} and marked Estimated in the report. Where a route's emissions are dominated by road transport abroad, the estimation error enters the result directly.",
+      "The sea and air factors have a **production region of the United States** (announced 2016 and 2017), and the air distance excludes routing detours, climb and high-altitude radiative forcing — both the actual flight distance and the climate impact exceed the figures reported here.",
     ],
     // Info: (20260802 - Luphia) 內文暫以英文回退：日文審計用詞我無法驗證準確度，
     // Info: (20260802 - Luphia) 譯錯的方法論說明比沒有說明更糟。結構與 token 已就位，翻譯可直接替換此陣列。

--- a/src/i18n/locales/ja/transportation_carbon_footprint_calculator.ts
+++ b/src/i18n/locales/ja/transportation_carbon_footprint_calculator.ts
@@ -11,6 +11,8 @@ export const transportationCarbonFootprintCalculator = {
     ai_parse_failed: "AIの解析に失敗しました",
     missing_params:
       "完全なパラメータを取得できません。AIの解析結果を確認するか、手動で入力してください。",
+    load_history_failed:
+      "履歴レポートを読み込めませんでした。しばらくしてからもう一度お試しください。",
   },
   payment: {
     fee_name: "カーボンフットプリント分析費用",

--- a/src/i18n/locales/ko/transportation_carbon_footprint_calculator.ts
+++ b/src/i18n/locales/ko/transportation_carbon_footprint_calculator.ts
@@ -170,10 +170,12 @@ export const transportationCarbonFootprintCalculator = {
       "아래 각 절에서 모든 수치가 어디서 나오는지 설명합니다. 결론을 어디까지 신뢰할 수 있는지만 알고 싶다면 제11절 「알려진 한계」로 바로 이동하세요.",
     limits_title: "이 수치를 쓰기 전에 반드시 읽어 주세요",
     read_full: "계산 방식 전문 보기",
+    // Info: (20260820 - Luphia) 限制摘要同 sections 以英文回退：韓文審計用詞我無法驗證準確度，
+    // Info: (20260820 - Luphia) 譯錯的限制摘要比沒有摘要更糟。用詞與 sections 一致，翻譯可一併替換。
     highlights: [
-      "산정 범위는 **운송 과정만** 포함합니다. 창고 보관, 하역, 포장은 물론 화물 자체의 생산과 폐기도 포함하지 않습니다. 이 수치는 제품의 전과정 탄소 발자국이 아닙니다.",
-      "도로망은 **현재 대만만 수록**합니다. 대만 밖 육상 구간은 대권 거리 × {{landTortuosity}}로 추정하고 보고서에 「추정치」로 표시합니다. 대만 밖 육상 운송이 주가 되는 경로라면 그 추정 오차가 결과에 그대로 들어갑니다.",
-      "해상과 항공 계수는 **생산 지역이 미국**(공표 연도 2016년과 2017년)이며, 항공 거리는 우회 비행과 고고도 복사 강제력을 포함하지 않으므로 실제 영향은 이 보고서의 수치보다 큽니다.",
+      "The scope covers **transport only**: no warehousing, loading and unloading, or packaging, and nothing from the production or disposal of the goods themselves. The result is therefore not the full life-cycle carbon footprint of the shipment.",
+      "The road network **currently covers Taiwan only**: road legs outside Taiwan are estimated from straight-line distance times a tortuosity factor of {{landTortuosity}} and marked Estimated in the report. Where a route's emissions are dominated by road transport abroad, the estimation error enters the result directly.",
+      "The sea and air factors have a **production region of the United States** (announced 2016 and 2017), and the air distance excludes routing detours, climb and high-altitude radiative forcing — both the actual flight distance and the climate impact exceed the figures reported here.",
     ],
     // Info: (20260802 - Luphia) 內文暫以英文回退：韓文審計用詞我無法驗證準確度，
     // Info: (20260802 - Luphia) 譯錯的方法論說明比沒有說明更糟。結構與 token 已就位，翻譯可直接替換此陣列。

--- a/src/i18n/locales/ko/transportation_carbon_footprint_calculator.ts
+++ b/src/i18n/locales/ko/transportation_carbon_footprint_calculator.ts
@@ -11,6 +11,8 @@ export const transportationCarbonFootprintCalculator = {
     ai_parse_failed: "AI 구문 분석 실패",
     missing_params:
       "전체 매개변수를 가져올 수 없습니다. AI 분석 결과를 확인하거나 수동으로 입력하세요.",
+    load_history_failed:
+      "과거 보고서를 불러올 수 없습니다. 잠시 후 다시 시도해 주세요.",
   },
   payment: {
     fee_name: "탄소 발자국 분석 비용",

--- a/src/i18n/locales/zh_cn/transportation_carbon_footprint_calculator.ts
+++ b/src/i18n/locales/zh_cn/transportation_carbon_footprint_calculator.ts
@@ -8,6 +8,7 @@ export const transportationCarbonFootprintCalculator = {
     missing_input: "请输入运输路线描述，或展开进阶设定手动输入完整参数。",
     ai_parse_failed: "AI 解析失败",
     missing_params: "无法取得完整参数，请确认 AI 解析结果或手动输入。",
+    load_history_failed: "无法载入历史报告，请稍后再试。",
   },
   payment: {
     fee_name: "碳足迹分析费用",

--- a/src/i18n/locales/zh_cn/transportation_carbon_footprint_calculator.ts
+++ b/src/i18n/locales/zh_cn/transportation_carbon_footprint_calculator.ts
@@ -163,10 +163,12 @@ export const transportationCarbonFootprintCalculator = {
       "以下逐节说明每一个数字是怎么来的。若只想知道结论的可信范围，直接看第十一节「已知限制」。",
     limits_title: "使用这份数字前必读",
     read_full: "看完整计算方式说明",
+    // Info: (20260820 - Luphia) 限制摘要同 sections 以英文回退：審計用詞的正確性需母語者覆核，
+    // Info: (20260820 - Luphia) 譯錯的限制摘要比沒有摘要更糟。用詞與 sections 一致，翻譯可一併替換。
     highlights: [
-      "计算范围**只含运输过程**：不含仓储、装卸、包装，也不含货物本身的生产与废弃。这份数字不等于产品的完整生命周期碳足迹。",
-      "道路路网**目前仅覆盖台湾**：境外的陆运段以直线距离乘 {{landTortuosity}} 推估，并在报告中标上「估算值」。若某条路线以境外陆运为主，推估误差会直接进入结果。",
-      "海运与空运系数的**生产区域为美国**（公告年份 2016 与 2017），且空运距离未计绕飞与高空辐射强迫加成，实际影响高于本报告数值。",
+      "The scope covers **transport only**: no warehousing, loading and unloading, or packaging, and nothing from the production or disposal of the goods themselves. The result is therefore not the full life-cycle carbon footprint of the shipment.",
+      "The road network **currently covers Taiwan only**: road legs outside Taiwan are estimated from straight-line distance times a tortuosity factor of {{landTortuosity}} and marked Estimated in the report. Where a route's emissions are dominated by road transport abroad, the estimation error enters the result directly.",
+      "The sea and air factors have a **production region of the United States** (announced 2016 and 2017), and the air distance excludes routing detours, climb and high-altitude radiative forcing — both the actual flight distance and the climate impact exceed the figures reported here.",
     ],
     // Info: (20260802 - Luphia) 內文暫以英文回退：審計用詞的正確性需母語者覆核，
     // Info: (20260802 - Luphia) 譯錯的方法論說明比沒有說明更糟。結構與 token 已就位，翻譯可直接替換此陣列。

--- a/src/i18n/locales/zh_tw/transportation_carbon_footprint_calculator.ts
+++ b/src/i18n/locales/zh_tw/transportation_carbon_footprint_calculator.ts
@@ -8,6 +8,7 @@ export const transportationCarbonFootprintCalculator = {
     missing_input: "請輸入運輸路線描述，或展開進階設定手動輸入完整參數。",
     ai_parse_failed: "AI 解析失敗",
     missing_params: "無法取得完整參數，請確認 AI 解析結果或手動輸入。",
+    load_history_failed: "無法載入歷史報告，請稍後再試。",
   },
   payment: {
     fee_name: "碳足跡分析費用",


### PR DESCRIPTION
### DEVELOP

- [X] Description: 兩件事，各自一個 commit。

  **1. 修掉 #6693 —— 四處使用者可見字串繞過 i18n**

  歷史清單的「核算類型」欄與三處錯誤訊息直接寫死繁體中文，非中文使用者會在英日韓介面裡看到中文。其中兩處的翻譯鍵**早就存在，只是沒有人接上**：`error.missing_input` 與 `error.missing_params` 已在五份語言檔定義，全庫卻沒有任何消費者 —— 翻譯早就寫好了，畫面顯示的卻是硬編碼那一份，改語言檔完全不會生效。

  | 位置 | 改法 |
  | --- | --- |
  | 「核算類型」欄 | 改用 `ui.tab_mileage` / `ui.tab_analysis` |
  | 缺少描述 | 接上既有的 `error.missing_input`（原本未使用） |
  | 參數不完整 | 接上既有的 `error.missing_params`（原本未使用） |
  | AI 解析失敗（兩處） | 接上既有的 `error.ai_parse_failed` |
  | 載入歷史失敗 | 原本連鍵都沒有，新增 `error.load_history_failed` 並補齊五語 |

  「核算類型」欄沿用分頁標籤的鍵而不新增兩個鍵：這一欄回答的正是「這筆載入後會切到哪個分頁」，兩處必須是同一個詞 —— 分開定義就會出現「清單寫 A、分頁寫 B」而沒有任何機制會發現。

  順帶把 `"calculate_batch"` 五處裸字串收斂到既有的 `MILEAGE_ACTION.CALCULATE_BATCH`（`constants/analysis.ts` 早已定義）。

  **2. 限制摘要在 ja / ko / zh_cn 改為英文回退**

  #6692 為五種語言都寫了 `methodology.highlights`（貼在報告結果旁的三條限制摘要）。但那三條與同一區塊的 `sections` 是**同一類文字** —— 查核者用來判斷數字能不能當申報依據的審計陳述 —— 而 `sections` 早在 2026-08-02 就已決定在這三種語言維持英文回退，理由記在該陣列上方的註解：審計用詞的準確度無法自行驗證，譯錯的說明比沒有說明更糟。

  同一份判斷沒有理由對 highlights 例外，而且 highlights 的風險更高：它不在收合區裡，而是直接貼在數字旁邊，被讀到的機率遠高於完整說明。

  - ja / ko / zh_cn 的 `highlights` 改為英文，並以相同格式在陣列上方記錄理由。
  - 英文用詞刻意與 `sections` 對齊（`Road` 而非 `land`、`straight-line distance times a tortuosity factor`、`production region of the United States`）—— 回退的目的正是「與完整說明讀起來是同一份文件」。
  - `en` 的 highlights 一併照上述用詞改寫（它同時是三個回退語言顯示的內容）；`zh_tw` 不動（來源語言）。
  - `intro` / `limits_title` / `read_full` 仍為各語言翻譯：那三個是導覽用的標題與連結文字，不承載審計陳述，而使用者需要看得懂「這裡是什麼、點下去會到哪」。

  版號更新至 `0.12.0+216`。

#### Related Issues

- [X] Issue Number: #6693（第二個 commit 無對應 issue，係 #6692 合併後依 Luphia 指示調整；相關背景見 #6694）

#### Checklist

- [x] Used `@` in import paths.
- [x] Verified naming convention compliance ([Naming Convention Guidelines](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md)).
- [x] Coding style verification: checked（每個 commit 的 pre-commit 都跑完整 `npm run test`：typecheck / eslint / 222 suites 2866 tests / tz 55 tests，全綠）
- [x] new Library: 0
- [x] new Class / Component: 0
- [x] new loop: 0
- [x] new recursive: 0
- [x] high risk: 0（純呈現層字串替換，未動邏輯、API 與資料庫）
- [x] new sql: 0

#### UML Diagrams

- None

#### Additional Notes

- **本 PR 原本以 #6692 為基底（stacked），#6692 已於 2026-08-20 合併，base 已自動改指向 `develop` 並重新以 develop 為基底重建，歷史線性乾淨。**
- **`handleLoadHistory` 的依賴陣列加入 `t`**（eslint `exhaustive-deps` 要求）。這不會讓它變得不穩定：`I18nProvider` 位於 root layout，其 state 只在切換語言時變動，故 `t` 的識別在同一語言下是穩定的 —— 依賴 `handleLoadHistory` 的 `analysisId` 自動載入 effect 不會因此每次 render 都重跑。
- **新增的兩條測試斷言是回退狀態的防漂移機制。** `logistics_guide.test.ts` 斷言三個回退語言的 highlights 與 `en` **逐字相同**，且 `zh_tw` 必須不等於 `en`。沒有前者，英文文案更新後三份回退會靜默留在舊版；而回退內容既然是英文，任何差異就只可能是漏同步，不可能是翻譯。這同時是「翻譯落地」的驗收點：某語言不再等於 `en`，即代表它已翻譯，屆時應一併移除該語言檔的回退註解。
- **#6694 已重新界定，不是缺陷。** `methodology.sections` 在 ja / ko / zh_cn 維持英文回退是程式碼裡有註解記錄的刻意決定，該 issue 已改寫為追蹤「待母語者覆核翻譯」的 `documentation` 任務。
- **驗收方式**：在 en / ja / ko / zh_cn 四種語言下確認「歷史報告」分頁的「核算類型」欄跟著語言切換；清空描述欄與進階參數後按「產生分析報告」，確認錯誤訊息也跟著語言切換；並確認限制摘要卡片在 ja / ko / zh_cn 顯示英文、標題與連結文字仍為當地語言。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
