### PR TITLE
feat(contracts): SCW 的 ERC-721 接收能力與可升級 factory（ADR 021）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ pdfs/
 
 # PDF 光柵化驗證工具的相依（README 指示在該目錄 npm i；playwright 會拉數百 MB）
 tools/pdf_harness/node_modules/
+
+# Info: (20260821 - Luphia) forge test 的產物（見 foundry.toml）
+/forge_out
+/forge_cache

--- a/contracts/fido2_account_anchor.sol
+++ b/contracts/fido2_account_anchor.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {
+    Initializable
+} from "./lib/@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {
+    ERC1967Utils
+} from "./lib/@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
+
+// Info: (20260821 - Luphia) anchor 只需要 factory 的這一個讀取器
+interface IAccountImplementationProvider {
+    function accountImplementation() external view returns (address);
+}
+
+/**
+ * Info: (20260821 - Luphia)
+ * @title Fido2AccountAnchor
+ * @dev 錢包位址的**錨點實作**：它存在的唯一目的，是讓 CREATE2 位址推導
+ * 永遠不隨帳戶實作版本改變。
+ *
+ * ## 它解的問題
+ *
+ * V1 factory 的 `getAddress` 把 `accountImplementation` 編進 CREATE2 的
+ * init-code hash——實作一換，**同一組 credential 推導出的位址就變了**。
+ * 這正是 V1 factory 無法支援升級的根因：不是缺一個 setter，而是位址推導
+ * 綁死了實作。
+ *
+ * ## 它怎麼解
+ *
+ * 所有 proxy 一律以 anchor（本合約，位址永久固定）為建構參數部署，
+ * 因此推導只依賴 (factory, anchor, credential, salt)。`initialize` 在
+ * proxy 建構的同一筆交易內：
+ *
+ * 1. 寫入三把鑰匙（storage 佈局**必須**與 Fido2Account 完全一致——
+ *    slot0 credentialId / slot1 pubKeyX / slot2 pubKeyY；Initializable
+ *    是 ERC-7201 命名空間儲存，不佔序列 slot）
+ * 2. 向 factory（proxy 建構期間的 `msg.sender`）讀取**當下**的正式實作
+ * 3. 把 ERC-1967 implementation slot 自我升級過去
+ *
+ * 完成後這個 proxy 就是一個普通的 UUPS 帳戶，之後的升級照舊由錢包持有人
+ * 自己簽（`_authorizeUpgrade` 限 EntryPoint），anchor 不再參與。
+ *
+ * ## 安全性
+ *
+ * - `initializer` 寫入的是與正式實作**同一個** ERC-7201 slot，因此升級過去
+ *   之後 `initialize` 不可能被再呼叫一次（劫持鑰匙的路被鎖死）。
+ * - anchor 本體 `_disableInitializers()`：沒有人能初始化 anchor 自己。
+ * - 任何人都可以拿 anchor 去部署自己的 proxy 配自己的假 factory——那是
+ *   他自己的 proxy，與本系統的推導（綁定我們的 factory 位址）無關。
+ */
+contract Fido2AccountAnchor is Initializable {
+    // Info: (20260821 - Luphia) 與 Fido2Account 逐 slot 對齊，順序不可動
+    bytes public credentialId;
+    uint256 public pubKeyX;
+    uint256 public pubKeyY;
+
+    error AnchorImplementationMissing();
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        bytes calldata _credentialId,
+        uint256 _pubKeyX,
+        uint256 _pubKeyY
+    ) public initializer {
+        credentialId = _credentialId;
+        pubKeyX = _pubKeyX;
+        pubKeyY = _pubKeyY;
+
+        address implementation = IAccountImplementationProvider(msg.sender)
+            .accountImplementation();
+        if (implementation == address(0)) {
+            revert AnchorImplementationMissing();
+        }
+        /**
+         * Info: (20260821 - Luphia) 空 data：只換 slot、不再呼叫任何初始化——
+         * 鑰匙已經寫好，而正式實作的 initialize 也已被上面的 initializer 鎖住。
+         */
+        ERC1967Utils.upgradeToAndCall(implementation, "");
+    }
+}

--- a/contracts/fido2_account_factory_v2.sol
+++ b/contracts/fido2_account_factory_v2.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Create2} from "./lib/@openzeppelin/contracts/utils/Create2.sol";
+import {
+    ERC1967Proxy
+} from "./lib/@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {
+    AccessControl
+} from "./lib/@openzeppelin/contracts/access/AccessControl.sol";
+import {
+    IEntryPoint
+} from "./lib/@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {Fido2Account} from "./fido2_account.sol";
+import {Fido2AccountV2} from "./fido2_account_v2.sol";
+import {Fido2AccountAnchor} from "./fido2_account_anchor.sol";
+
+/**
+ * Info: (20260821 - Luphia)
+ * @title Fido2AccountFactoryV2
+ * @dev 可升級帳戶實作的 factory（D 方案）。與 V1 的差別只有一件事，
+ * 而那件事有兩半：
+ *
+ * 1. `accountImplementation` 從 immutable 變成可由管理者更換——**新**錢包
+ *    從此拿到當下的正式實作，帳戶實作升版不再需要換 factory。
+ * 2. CREATE2 位址推導改綁**anchor**（見 fido2_account_anchor.sol）而不是實作：
+ *    V1 把實作位址編進 init-code hash，實作一換位址就變——那才是 V1 不能
+ *    支援升級的根因。anchor 讓 `getAddress` 對同一組 credential **永遠**回
+ *    同一個位址，不論實作換過幾版；`webauthn.service` 那些「從 factory 回推
+ *    位址」的路徑因此對新舊使用者都持續正確。
+ *
+ * ## 信任邊界（刻意維持）
+ *
+ * `setAccountImplementation` 只影響**之後建立**的錢包。既有錢包的實作存在
+ * 各自 proxy 的 ERC-1967 slot，升級只能由錢包持有人簽 UserOp 觸發
+ * （`Fido2Account._authorizeUpgrade` 限 EntryPoint）。這裡**沒有**、也不該有
+ * 讓平台單方面替既有錢包換邏輯的能力——那是 beacon 模式被否決的原因：
+ * beacon 的持有者可以一次替全體錢包換掉任何邏輯（含移轉資產），
+ * 與本產品「資產移動必經持有人簽章」的既定邊界（服務條款 §3.3）相反。
+ *
+ * ## 與 V1 的相容
+ *
+ * - `AccountCreated` 事件的型別與 indexed 完全同形（app 以事件掃描回查位址，
+ *   topic0 只看型別）。
+ * - `createAccount` / `getAddress` / `getAccountByCredentialId` 介面不變。
+ * - V1 factory 與其既有錢包**不受影響**：兩個 factory 並存，既有使用者一律
+ *   以 DB 記錄的位址為準（不得對舊使用者用新 factory 重推位址——推導基底
+ *   不同，必然對不上）。
+ */
+contract Fido2AccountFactoryV2 is AccessControl {
+    // Info: (20260821 - Luphia) 位址推導的錨點：永久固定，這是「可升級」的前提
+    Fido2AccountAnchor public immutable accountAnchor;
+
+    // Info: (20260821 - Luphia) 當下的正式實作：只作用於之後建立的錢包
+    address public accountImplementation;
+
+    // Info: (20260821 - Luphia) credential hash → 已部署位址（與 V1 同用途）
+    mapping(bytes32 => address) public fido2ToAccount;
+
+    // Info: (20260821 - Luphia) 與 V1 逐型別同形（app 的事件掃描不需要改 ABI）
+    event AccountCreated(
+        address indexed scw,
+        uint256 pubKeyX,
+        uint256 pubKeyY,
+        uint256 salt,
+        string credentialId,
+        string username,
+        string imageUrl
+    );
+
+    event AccountImplementationUpdated(
+        address indexed previousImplementation,
+        address indexed newImplementation
+    );
+
+    error ImplementationHasNoCode(address implementation);
+
+    constructor(IEntryPoint _entryPoint, address defaultAdmin) {
+        _grantRole(DEFAULT_ADMIN_ROLE, defaultAdmin);
+        accountAnchor = new Fido2AccountAnchor();
+        // Info: (20260821 - Luphia) 出廠即 V2（含 ERC-721 接收），不會有一批 V1 新錢包
+        accountImplementation = address(new Fido2AccountV2(_entryPoint));
+    }
+
+    /**
+     * Info: (20260821 - Luphia) 換正式實作。只驗「有 code」——實作的行為正確性
+     * 由部署流程的 canary 驗證把關（見 documents/architecture/scw_upgrade_plan_d.md），
+     * 合約層驗不出「validateUserOp 是不是被弄壞了」這種事。
+     */
+    function setAccountImplementation(
+        address newImplementation
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (newImplementation.code.length == 0) {
+            revert ImplementationHasNoCode(newImplementation);
+        }
+        emit AccountImplementationUpdated(
+            accountImplementation,
+            newImplementation
+        );
+        accountImplementation = newImplementation;
+    }
+
+    /**
+     * Info: (20260821 - Luphia) 建立帳戶。proxy 以 anchor 為建構參數部署，
+     * anchor 的 initialize 會在同一筆交易內寫入鑰匙並自我升級到
+     * `accountImplementation`（讀的是**部署當下**的值）。
+     */
+    function createAccount(
+        bytes calldata credentialId,
+        uint256 pubKeyX,
+        uint256 pubKeyY,
+        uint256 salt,
+        string calldata username,
+        string calldata imageUrl
+    ) public returns (Fido2Account ret) {
+        address addr = getAddress(credentialId, pubKeyX, pubKeyY, salt);
+        if (addr.code.length > 0) {
+            return Fido2Account(payable(addr));
+        }
+
+        bytes memory initCode = abi.encodeCall(
+            Fido2AccountAnchor.initialize,
+            (credentialId, pubKeyX, pubKeyY)
+        );
+        ret = Fido2Account(
+            payable(
+                new ERC1967Proxy{salt: bytes32(salt)}(
+                    address(accountAnchor),
+                    initCode
+                )
+            )
+        );
+
+        fido2ToAccount[keccak256(credentialId)] = address(ret);
+
+        emit AccountCreated(
+            address(ret),
+            pubKeyX,
+            pubKeyY,
+            salt,
+            string(credentialId),
+            username,
+            imageUrl
+        );
+    }
+
+    /**
+     * Info: (20260821 - Luphia) 反事實位址。只依賴 anchor（immutable），
+     * 因此**跨實作版本恆定**——這一點有 forge 測試釘住（升版前後同 credential
+     * 必須推出同一個位址）。
+     */
+    function getAddress(
+        bytes calldata credentialId,
+        uint256 pubKeyX,
+        uint256 pubKeyY,
+        uint256 salt
+    ) public view returns (address) {
+        bytes memory initCode = abi.encodeCall(
+            Fido2AccountAnchor.initialize,
+            (credentialId, pubKeyX, pubKeyY)
+        );
+        return
+            Create2.computeAddress(
+                bytes32(salt),
+                keccak256(
+                    abi.encodePacked(
+                        type(ERC1967Proxy).creationCode,
+                        abi.encode(address(accountAnchor), initCode)
+                    )
+                )
+            );
+    }
+
+    function getAccountByCredentialId(
+        bytes calldata credentialId
+    ) public view returns (address) {
+        return fido2ToAccount[keccak256(credentialId)];
+    }
+}

--- a/contracts/fido2_account_v2.sol
+++ b/contracts/fido2_account_v2.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Fido2Account} from "./fido2_account.sol";
+import {
+    IEntryPoint
+} from "./lib/@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {
+    IERC721Receiver
+} from "./lib/@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+
+/**
+ * Info: (20260821 - Luphia)
+ * @title Fido2AccountV2
+ * @dev V1 加上 ERC-721 接收能力，其他一行不動（D 方案，最小差異原則）。
+ *
+ * 為什麼需要 V2：`DynamicKYCMembership.mintCard` 用 `_safeMint`，對有 code 的
+ * 收受人會呼叫 `onERC721Received` 並要求回傳 selector——V1 沒有這個函式，
+ * 因此鑄卡對所有既有錢包**必定** revert `ERC721InvalidReceiver`（鏈上已實測，
+ * 三個 SCW 皆 `0x64a0ae92`，對照組 EOA 成功）。
+ *
+ * 刻意**不**加的東西，與原因：
+ *
+ * - `receive()`：會改變「這個地址能不能收原生幣」的語意。升級壞掉的代價是
+ *   錢包永久鎖死（見下），最小差異原則壓過便利性。
+ * - 任何 storage：V1 的佈局是 slot0 credentialId / slot1 pubKeyX / slot2 pubKeyY
+ *   （Initializable 與 UUPSUpgradeable 皆為 ERC-7201 命名空間儲存，不佔序列 slot；
+ *   BaseAccount 只有常數）。V2 純加函式，佈局不變，既有錢包升級後狀態原封不動。
+ *
+ * 升級路徑（僅供既有錢包）：`_authorizeUpgrade` 沿用 V1 的 EntryPoint 限定——
+ * 只有錢包持有人簽出的 UserOp 能觸發升級，平台**沒有**單方面替使用者換邏輯的
+ * 後門。這是刻意保留的信任邊界（與 chain_receipt_status 測試釘住的
+ * 「平台無權單方面銷毀成員代幣」同一條線）。
+ *
+ * ⚠️ 升級的唯一重大風險：若某個新版本弄壞 `validateUserOp` 或 `_authorizeUpgrade`，
+ * 該錢包**永久鎖死**（再也簽不出任何 UserOp，包括修復用的再升級）。因此每一版
+ * 都必須先在本地鏈對 canary 錢包完整驗證（簽章、轉點、再升級一次）才能開放。
+ */
+contract Fido2AccountV2 is Fido2Account, IERC721Receiver {
+    constructor(IEntryPoint anEntryPoint) Fido2Account(anEntryPoint) {}
+
+    /**
+     * Info: (20260821 - Luphia) `_safeMint` / `safeTransferFrom` 的接收確認。
+     * pure：這個錢包無條件接受任何 ERC-721（是否「認得」某張卡是離鏈判斷的事，
+     * 合約層拒收只會把鑄造打回 revert，回到 V1 的問題）。
+     */
+    function onERC721Received(
+        address,
+        address,
+        uint256,
+        bytes calldata
+    ) external pure override returns (bytes4) {
+        return IERC721Receiver.onERC721Received.selector;
+    }
+
+    /**
+     * Info: (20260821 - Luphia) ERC-165。除了標準用途，這也是離鏈 worker 的探針：
+     * 鑄卡前以 `supportsInterface(0x150b7a02)` 一次 eth_call 判斷錢包能不能收——
+     * V1 沒有這個函式（呼叫會 revert → 視為 false），升級完成的下一輪掃描
+     * 自動變 true，卡片開始鑄造，離鏈側不需要任何改動或重置。
+     */
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return
+            interfaceId == type(IERC721Receiver).interfaceId ||
+            interfaceId == 0x01ffc9a7; // Info: (20260821 - Luphia) ERC-165 自身
+    }
+
+    // Info: (20260821 - Luphia) 供營運確認某個 proxy 目前跑的是哪一版實作
+    function accountVersion() external pure returns (uint256) {
+        return 2;
+    }
+}

--- a/contracts/forge_test/scw_upgrade.t.sol
+++ b/contracts/forge_test/scw_upgrade.t.sol
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Fido2Account} from "../fido2_account.sol";
+import {Fido2AccountV2} from "../fido2_account_v2.sol";
+import {Fido2AccountAnchor} from "../fido2_account_anchor.sol";
+import {Fido2AccountFactory} from "../fido2_account_factory.sol";
+import {Fido2AccountFactoryV2} from "../fido2_account_factory_v2.sol";
+import {DynamicKYCMembership} from "../dynamic_kyc_membership.sol";
+import {
+    IEntryPoint
+} from "../lib/@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+
+/**
+ * Info: (20260821 - Luphia) D 方案的合約級驗證（forge test）。
+ *
+ * 這一組把整條升級路線的**不變式**釘在鏈上語意層，而不是留在設計文件裡：
+ *
+ * 1. V2 錢包收得到會員卡（V1 的 `ERC721InvalidReceiver` 在此消失）
+ * 2. `getAddress` 跨實作版本**恆定**——這是 factory「可升級」的定義本身；
+ *    V1 factory 做不到正是因為它把實作位址編進了推導
+ * 3. 既有 V1 錢包由**持有人（EntryPoint 路徑）**升級後收得到卡，且三把鑰匙原封不動
+ * 4. 沒升級的 V1 錢包行為完全不變（仍收不到卡，也不受任何新部署影響）
+ * 5. 劫持路徑全部鎖死：initialize 不可重跑、anchor 不可被初始化、
+ *    換實作限管理者、升級限 EntryPoint
+ *
+ * 不用 forge-std（repo 沒有 vendor 它）：cheatcode 以最小 Vm 介面直接呼叫。
+ */
+interface Vm {
+    function prank(address sender) external;
+
+    function expectRevert() external;
+
+    function load(
+        address target,
+        bytes32 slot
+    ) external view returns (bytes32);
+}
+
+contract ScwUpgradeTest {
+    Vm internal constant vm =
+        Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+    // Info: (20260821 - Luphia) ERC-1967 implementation slot
+    bytes32 internal constant IMPL_SLOT =
+        0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    // Info: (20260821 - Luphia) EntryPoint 只被拿來比對 msg.sender，dummy 位址即可
+    address internal constant ENTRY_POINT = address(0xE9);
+    address internal constant STRANGER = address(0xBad);
+
+    bytes internal constant CRED = hex"c0ffee01";
+    uint256 internal constant PKX = 111;
+    uint256 internal constant PKY = 222;
+
+    DynamicKYCMembership internal card;
+    Fido2AccountFactory internal factoryV1;
+    Fido2AccountFactoryV2 internal factoryV2;
+
+    function setUp() public {
+        card = new DynamicKYCMembership(address(this));
+        factoryV1 = new Fido2AccountFactory(IEntryPoint(ENTRY_POINT));
+        factoryV2 = new Fido2AccountFactoryV2(
+            IEntryPoint(ENTRY_POINT),
+            address(this)
+        );
+    }
+
+    // ── 1) 新錢包收得到卡 ────────────────────────────────────────────
+
+    function testMintToFactoryV2WalletSucceeds() public {
+        address wallet = address(
+            factoryV2.createAccount(CRED, PKX, PKY, 0, "u", "i")
+        );
+
+        uint256 tokenId = card.mintCard(wallet, "uri-1");
+
+        require(card.ownerOf(tokenId) == wallet, "card not delivered");
+        // Info: (20260821 - Luphia) 鑰匙由 anchor 寫入後必須讀得回來
+        require(Fido2Account(payable(wallet)).pubKeyX() == PKX, "pubKeyX lost");
+        require(Fido2Account(payable(wallet)).pubKeyY() == PKY, "pubKeyY lost");
+    }
+
+    // Info: (20260821 - Luphia) worker 的探針語意：V2 回 true
+    function testV2WalletAnswersReceiverProbe() public {
+        address wallet = address(
+            factoryV2.createAccount(CRED, PKX, PKY, 0, "u", "i")
+        );
+
+        require(
+            Fido2AccountV2(payable(wallet)).supportsInterface(0x150b7a02),
+            "probe should be true"
+        );
+    }
+
+    // ── 2) 位址跨版本恆定 ────────────────────────────────────────────
+
+    function testAddressStableAcrossImplementationBump() public {
+        address before = factoryV2.getAddress(CRED, PKX, PKY, 0);
+
+        address newImpl = address(new Fido2AccountV2(IEntryPoint(ENTRY_POINT)));
+        factoryV2.setAccountImplementation(newImpl);
+
+        require(
+            factoryV2.getAddress(CRED, PKX, PKY, 0) == before,
+            "address must not change with implementation"
+        );
+
+        // Info: (20260821 - Luphia) 部署落在同一個位址，且實作是**換過之後**的那一版
+        address wallet = address(
+            factoryV2.createAccount(CRED, PKX, PKY, 0, "u", "i")
+        );
+        require(wallet == before, "deployed at a different address");
+        require(
+            address(uint160(uint256(vm.load(wallet, IMPL_SLOT)))) == newImpl,
+            "new wallet should run the bumped implementation"
+        );
+    }
+
+    // Info: (20260821 - Luphia) V1 factory 的反例：它的推導綁實作，因此天生不可升級。
+    // 這條釘住「為什麼需要 V2 factory」的事實本身——V1 兩個 factory 實例
+    // （= 兩個不同 implementation 位址）對同一組 credential 推出不同位址。
+    function testV1DerivationDependsOnImplementation() public {
+        Fido2AccountFactory another = new Fido2AccountFactory(
+            IEntryPoint(ENTRY_POINT)
+        );
+
+        require(
+            factoryV1.getAddress(CRED, PKX, PKY, 0) !=
+                another.getAddress(CRED, PKX, PKY, 0),
+            "v1 derivation unexpectedly implementation-independent"
+        );
+    }
+
+    // ── 3) 既有 V1 錢包：升級前收不到、升級後收得到、鑰匙不動 ──────────
+
+    function testV1WalletUpgradePath() public {
+        address wallet = address(
+            factoryV1.createAccount(CRED, PKX, PKY, 0, "u", "i")
+        );
+
+        // Info: (20260821 - Luphia) 升級前：正是生產環境實測到的 ERC721InvalidReceiver
+        vm.expectRevert();
+        card.mintCard(wallet, "uri-1");
+
+        // Info: (20260821 - Luphia) 持有人簽出的 UserOp 由 EntryPoint 執行升級
+        address v2Impl = address(new Fido2AccountV2(IEntryPoint(ENTRY_POINT)));
+        vm.prank(ENTRY_POINT);
+        Fido2AccountV2(payable(wallet)).upgradeToAndCall(v2Impl, "");
+
+        uint256 tokenId = card.mintCard(wallet, "uri-1");
+        require(card.ownerOf(tokenId) == wallet, "card not delivered");
+        require(
+            Fido2Account(payable(wallet)).pubKeyX() == PKX,
+            "keys must survive the upgrade"
+        );
+        require(
+            keccak256(Fido2Account(payable(wallet)).credentialId()) ==
+                keccak256(CRED),
+            "credentialId must survive the upgrade"
+        );
+    }
+
+    // ── 4) 沒升級的 V1 錢包完全不受影響 ─────────────────────────────
+
+    function testUntouchedV1WalletKeepsOldImplementation() public {
+        address wallet = address(
+            factoryV1.createAccount(CRED, PKX, PKY, 0, "u", "i")
+        );
+        bytes32 implBefore = vm.load(wallet, IMPL_SLOT);
+
+        // Info: (20260821 - Luphia) 全套新部署 + 換版都發生了
+        Fido2AccountFactoryV2 f2 = new Fido2AccountFactoryV2(
+            IEntryPoint(ENTRY_POINT),
+            address(this)
+        );
+        f2.setAccountImplementation(
+            address(new Fido2AccountV2(IEntryPoint(ENTRY_POINT)))
+        );
+        f2.createAccount(hex"beef", 1, 2, 0, "u", "i");
+
+        require(
+            vm.load(wallet, IMPL_SLOT) == implBefore,
+            "v1 wallet implementation must be untouched"
+        );
+
+        // Info: (20260821 - Luphia) 探針對 V1 錢包必須是 revert（worker 視為 false）
+        (bool ok, ) = wallet.staticcall(
+            abi.encodeWithSignature("supportsInterface(bytes4)", bytes4(0x150b7a02))
+        );
+        require(!ok, "v1 wallet should not answer the probe");
+    }
+
+    // ── 5) 劫持路徑 ────────────────────────────────────────────────
+
+    function testInitializeCannotRerunAfterCreation() public {
+        address wallet = address(
+            factoryV2.createAccount(CRED, PKX, PKY, 0, "u", "i")
+        );
+
+        vm.expectRevert();
+        Fido2Account(payable(wallet)).initialize(hex"dead", 9, 9);
+    }
+
+    function testAnchorItselfCannotBeInitialized() public {
+        Fido2AccountAnchor anchor = factoryV2.accountAnchor();
+
+        vm.expectRevert();
+        anchor.initialize(hex"dead", 9, 9);
+    }
+
+    function testSetImplementationRequiresAdmin() public {
+        address impl = address(new Fido2AccountV2(IEntryPoint(ENTRY_POINT)));
+
+        vm.prank(STRANGER);
+        vm.expectRevert();
+        factoryV2.setAccountImplementation(impl);
+    }
+
+    function testSetImplementationRejectsNonContract() public {
+        vm.expectRevert();
+        factoryV2.setAccountImplementation(STRANGER);
+    }
+
+    function testUpgradeRequiresEntryPoint() public {
+        address wallet = address(
+            factoryV2.createAccount(CRED, PKX, PKY, 0, "u", "i")
+        );
+        address impl = address(new Fido2AccountV2(IEntryPoint(ENTRY_POINT)));
+
+        // Info: (20260821 - Luphia) 平台（或任何非 EntryPoint）不能替錢包換邏輯
+        vm.expectRevert();
+        Fido2AccountV2(payable(wallet)).upgradeToAndCall(impl, "");
+    }
+
+    // ── 冪等 ───────────────────────────────────────────────────────
+
+    function testCreateAccountIsIdempotent() public {
+        address first = address(
+            factoryV2.createAccount(CRED, PKX, PKY, 0, "u", "i")
+        );
+        address second = address(
+            factoryV2.createAccount(CRED, PKX, PKY, 0, "u", "i")
+        );
+
+        require(first == second, "createAccount must be idempotent");
+        require(
+            factoryV2.getAccountByCredentialId(CRED) == first,
+            "credential lookup broken"
+        );
+    }
+}

--- a/documents/architecture/decisions/021_scw_erc721_receiver_and_upgradeable_factory.md
+++ b/documents/architecture/decisions/021_scw_erc721_receiver_and_upgradeable_factory.md
@@ -87,7 +87,7 @@ forge `testV2WalletAnswersReceiverProbe` 與 `testUntouchedV1WalletKeepsOldImple
 2. **Canary**：在本地鏈對一個 V1 錢包做完整升級驗證（簽章、轉點、收卡、再升級一次），再對正式鏈的平台自有錢包重複一次
 3. **託管批次**（4 個）：平台代簽升級 UserOp，全程可觀測
 4. **新註冊切換**：env 的 `NEXT_PUBLIC_SCW_FACTORY_ADDRESS` 指向 V2 factory。**切換前必須逐一驗證所有 DB `user.address` 在鏈上都有 code**（factory 事件 2,144 ≈ 使用者 2,119，看似急切部署，仍須驗證）；V1 factory 位址保留在設定中，既有使用者的位址一律以 DB 為準，禁止對舊使用者重推
-5. **passkey 漸進升級**：app 在下次登入／付款時夾帶升級 UserOp（一次額外的生物辨識確認），滲透率跟著活躍度走
+5. **passkey 漸進升級**：app 在下次登入／付款時夾帶升級 UserOp（一次額外的生物辨識確認），滲透率跟著活躍度走。**告知通道是小鈴鐺**（PR #6701）：`scripts/request_wallet_upgrades.ts` 以與會員卡 worker 同一條 `supportsInterface` 探針，只對還不能收 ERC-721 的使用者發出「系統要求升級錢包」待辦——已升級的人不會收到一則按了沒事做的通知，dedupeKey 一人一則、重跑不重複
 6. 會員卡 worker 的探針邏輯（PR #6687 的 A 方案）在任何一步之前就可以先上——它對 V1 錢包的行為是便宜地跳過
 
 ## Consequences（後果）

--- a/documents/architecture/decisions/021_scw_erc721_receiver_and_upgradeable_factory.md
+++ b/documents/architecture/decisions/021_scw_erc721_receiver_and_upgradeable_factory.md
@@ -1,0 +1,104 @@
+# ADR 021: SCW 的 ERC-721 接收能力與可升級 factory (SCW ERC-721 Receiver & Upgradeable Factory)
+
+> **Date**: 2026-08-21
+> **Author**: Luphia
+> **Status**: Proposed（合約已寫並通過 forge 測試，尚未部署）
+> **關聯 ADR**: [016 第三方登入與託管錢包](./016_third_party_login_and_custodial_wallet.md)
+> **關聯程式碼**: `contracts/fido2_account_v2.sol`、`contracts/fido2_account_anchor.sol`、`contracts/fido2_account_factory_v2.sol`、`contracts/forge_test/scw_upgrade.t.sol`
+> **關聯設計**: `team_wallet_and_subscription_quota.md` §6.5（訂閱會員卡）
+
+---
+
+## Context（脈絡）
+
+訂閱會員卡（PR #6687）鑄造給團隊 OWNER 的錢包位址，而那個位址是 `Fido2Account` 智慧合約錢包（SCW）。鏈上實測（2026-08-21，本地鏈 20024）：
+
+- `DynamicKYCMembership.mintCard` 用 `_safeMint`，對有 code 的收受人要求 `onERC721Received` 回傳 selector
+- 部署中的 `Fido2Account` 實作（`0xeeb5c620…`）**沒有**這個函式（直接呼叫 → revert）
+- 對三個 SCW 模擬 `mintCard` 一律 revert `0x64a0ae92` = `ERC721InvalidReceiver`；對照組 EOA 成功
+- 依序排除的假設：白名單（`isBlacklisted=false`、錯誤 selector 不符 `0xdaf49ab9`）、權限（EOA 成功、不符 `0xe2517d3f`）、KYC（level 1 的 SCW 同樣 revert）、ISC（`mintCard` 非 payable；有 8,064 ISC 的 admin 結果相同）
+
+**所以：不動合約層，現有的 2,115 個 passkey 錢包一張會員卡都收不到。**
+
+而 V1 factory 有第二個結構性問題，讓「換一版實作」變得昂貴：
+
+```solidity
+// V1 getAddress：實作位址被編進 CREATE2 的 init-code hash
+abi.encode(address(accountImplementation), initCode)   // accountImplementation 是 immutable
+```
+
+實作一換，**同一組 credential 推導出的位址就變了**。V1 不能支援升級不是缺一個 setter，是位址推導綁死了實作。
+
+## Decision（決定）
+
+三個新合約，**既有已部署合約一個都不動**：
+
+### 1. `Fido2AccountV2` — V1 加上 ERC-721 接收，其他一行不動
+
+- `onERC721Received` 回 selector（無條件接受；「認不認得某張卡」是離鏈判斷）
+- `supportsInterface(0x150b7a02)` — 同時是離鏈 worker 的探針（見下）
+- `accountVersion() = 2` 供營運確認
+- **不加 `receive()`**：會改變「能不能收原生幣」的語意，而升級壞掉的代價是錢包永久鎖死，最小差異原則壓過便利性
+- **不加 storage**：V1 佈局是 slot0 `credentialId` / slot1 `pubKeyX` / slot2 `pubKeyY`（Initializable 與 UUPS 皆 ERC-7201 命名空間儲存），升級後狀態原封不動
+
+### 2. `Fido2AccountAnchor` — 位址推導的永久錨點
+
+所有新 proxy 一律以 anchor 為建構參數部署，推導只依賴 `(factory, anchor, credential, salt)`。anchor 的 `initialize` 在 proxy 建構的同一筆交易內寫入三把鑰匙、向 factory（`msg.sender`）讀取**當下**的正式實作、自我升級過去。完成後就是普通的 UUPS 帳戶。
+
+`initializer` 寫的是與正式實作同一個 ERC-7201 slot → 升級後 `initialize` 不可能重跑（劫持鑰匙的路鎖死）；anchor 本體 `_disableInitializers()`。
+
+### 3. `Fido2AccountFactoryV2` — `accountImplementation` 可換
+
+- `setAccountImplementation` 限 `DEFAULT_ADMIN_ROLE`，只影響**之後建立**的錢包
+- `getAddress` 綁 anchor → **跨實作版本恆定**（有 forge 測試釘住）
+- `AccountCreated` 事件與 V1 逐型別同形（app 的事件掃描 ABI 不用改）
+
+### 被否決的替代方案
+
+| 方案 | 否決原因 |
+|---|---|
+| **Beacon proxy** | beacon 持有者可以一次替**全體**錢包換掉任何邏輯（含移轉資產）。與本產品「資產移動必經持有人簽章」的既定邊界（服務條款 §3.3、`chain_receipt_status` 測試釘住的同一條線）相反。位址穩定的問題由 anchor 解，不需要付這個信任代價 |
+| **factory 只加 mutable implementation（不加 anchor）** | 位址推導仍隨實作版本漂移，`webauthn.service` 的「從 factory 回推位址」路徑對舊使用者必然算錯——那是一整類會安靜發生的 bug |
+| **鑄給平台 EOA 代持** | 「卡是誰的」語意改變，與「鏈上為準＝會員卡狀態」的產品定義相牴觸 |
+| **改 `DynamicKYCMembership` 用 `_mint`** | 要重新部署卡片合約；且放棄接收確認等於允許把卡鑄進任何黑洞地址 |
+
+## 對現有錢包客戶的影響
+
+| 面向 | 結論 | 依據 |
+|---|---|---|
+| 不升級的錢包 | **零影響**：proxy 各自的 ERC-1967 slot 不動，付款、簽章、點數照舊；只是繼續收不到卡 | forge `testUntouchedV1WalletKeepsOldImplementation` |
+| 誰要動手 | passkey 2,115 人**各一次**生物辨識（升級 UserOp 夾進下次登入／付款流程）；託管 4 人由平台代簽靜默完成 | DB 實測 `users=2119 custodial=4` |
+| 覆蓋率 | **永遠不到 100%**（不回訪的使用者停在 V1）→ 混合狀態是常態設計，不是過渡 | — |
+| 資費 | 平台墊付（relayer 全額買單是現況，`bundler.service.ts` 註明），自營鏈成本趨近零 | 實測錢包 ISC 餘額 0、EntryPoint deposit 0，一切照常運作 |
+| 唯一重大風險 | 新版實作若弄壞 `validateUserOp` / `_authorizeUpgrade` → 該錢包**永久鎖死**（資產凍結，無法再簽任何 UserOp 修復） | 緩解：最小差異 + canary（見 Rollout） |
+
+## 離鏈側的接縫（讓 D 上線不需要再發版）
+
+worker 鑄卡前以一次 `eth_call` 探測 `supportsInterface(0x150b7a02)`：
+
+- V1 錢包沒有這個函式 → revert → 視為 false → 標記「錢包尚不具備接收能力」，**跳過、不算失敗、不燒重試次數**
+- 錢包升級完成的**下一輪掃描**探針變 true → 卡片自動開始鑄造，不需重置任何欄位
+
+forge `testV2WalletAnswersReceiverProbe` 與 `testUntouchedV1WalletKeepsOldImplementation` 分別釘住探針的兩側語意。
+
+## Rollout（部署順序，每一步可獨立回退）
+
+1. **部署** `Fido2AccountFactoryV2`（anchor 與 V2 實作由 factory 建構子自帶）——此刻對任何人零影響
+2. **Canary**：在本地鏈對一個 V1 錢包做完整升級驗證（簽章、轉點、收卡、再升級一次），再對正式鏈的平台自有錢包重複一次
+3. **託管批次**（4 個）：平台代簽升級 UserOp，全程可觀測
+4. **新註冊切換**：env 的 `NEXT_PUBLIC_SCW_FACTORY_ADDRESS` 指向 V2 factory。**切換前必須逐一驗證所有 DB `user.address` 在鏈上都有 code**（factory 事件 2,144 ≈ 使用者 2,119，看似急切部署，仍須驗證）；V1 factory 位址保留在設定中，既有使用者的位址一律以 DB 為準，禁止對舊使用者重推
+5. **passkey 漸進升級**：app 在下次登入／付款時夾帶升級 UserOp（一次額外的生物辨識確認），滲透率跟著活躍度走
+6. 會員卡 worker 的探針邏輯（PR #6687 的 A 方案）在任何一步之前就可以先上——它對 V1 錢包的行為是便宜地跳過
+
+## Consequences（後果）
+
+- ＋ 會員卡（與未來任何 ERC-721 / `safeTransferFrom` 資產）對升級後的錢包可用
+- ＋ 之後的實作升版只需 `setAccountImplementation`，不再換 factory、位址永久穩定
+- ＋ 錢包主權邊界不變：平台仍然沒有替既有錢包換邏輯的能力
+- － 永久的混合狀態：離鏈側必須以探針處理「這個錢包能不能收」，直到自然收斂
+- － 兩個 factory 並存的設定與文件成本；`webauthn.service` 的位址推導路徑需要一次稽核
+- － repo 多了 foundry 工具鏈（僅 `forge test` 用，`foundry.toml` 開 `via_ir`——V1 factory 的 7 參數 emit 在 legacy codegen 會 stack too deep）
+
+## 驗證
+
+`forge test`：12 條全綠。三條關鍵不變式做過變異驗證（推導改綁實作 → 2 紅；anchor 不自我升級 → 3 紅；initializer 鎖拿掉 → 1 紅）。jest 全套照跑不受影響（227 suites / 3,022 tests）。

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,14 @@
+# Info: (20260821 - Luphia) 只給合約測試用（forge test）。
+# app 的建置與 jest 完全不經過這裡；vendored 的 OZ / AA 函式庫以相對路徑
+# import，因此不需要 remappings。
+#
+# via_ir：V1 factory 的 AccountCreated emit 有 7 個引數，legacy codegen 會
+# stack too deep——這是既有合約的形狀，不是新合約引入的。
+[profile.default]
+src = "contracts"
+test = "contracts/forge_test"
+out = "forge_out"
+cache_path = "forge_cache"
+via_ir = true
+optimizer = true
+optimizer_runs = 200


### PR DESCRIPTION
### DEVELOP

- [X] Description: **D 方案（ADR 021）**：SCW 的 ERC-721 接收能力 + 可升級 factory。三個新合約，**既有已部署合約一個都不動、尚未部署任何東西**——本 PR 是合約原始碼、forge 測試與部署計畫。

## 為什麼需要

鏈上實測（2026-08-21，本地鏈 20024）：`mintCard` 用 `_safeMint`，部署中的 `Fido2Account`（`0xeeb5c620…`）沒有 `onERC721Received` —— 對三個 SCW 模擬一律 revert `0x64a0ae92` = `ERC721InvalidReceiver`，對照組 EOA 成功。白名單（`isBlacklisted=false`、selector 不符）、權限（EOA 成功）、KYC（level 1 同樣 revert）、ISC（`mintCard` 非 payable）四個假設逐一排除。**不動合約層，2,115 個 passkey 錢包一張會員卡都收不到。**

而 V1 factory 有第二個結構性問題：`getAddress` 把實作位址編進 CREATE2 的 init-code hash，**實作一換、同一組 credential 的位址就變** —— V1 不能支援升級不是缺 setter，是推導綁死了實作。

## 三個新合約

| 檔案 | 內容 |
|---|---|
| `fido2_account_v2.sol` | V1 + `onERC721Received` + `supportsInterface`，其他一行不動。刻意**不加** `receive()` 與任何 storage（升級壞掉的代價是錢包永久鎖死，最小差異壓過便利） |
| `fido2_account_anchor.sol` | 位址推導的**永久錨點**：推導只依賴 `(factory, anchor, credential, salt)`；`initialize` 在 proxy 建構的同一筆交易內寫鑰匙並自我升級到 factory 當下的正式實作，之後就是普通 UUPS 帳戶 |
| `fido2_account_factory_v2.sol` | `accountImplementation` 可由管理者更換，**只影響之後建立的錢包**；`AccountCreated` 事件與 V1 逐型別同形（app 的事件掃描 ABI 不用改） |

**Beacon 模式被否決**：beacon 持有者可以一次替全體錢包換掉任何邏輯（含移轉資產），與「資產移動必經持有人簽章」的既定邊界（服務條款 §3.3）相反。既有錢包的升級仍然只能由持有人簽 UserOp 觸發（`_authorizeUpgrade` 限 EntryPoint），**平台沒有後門** —— 這是刻意保留的信任邊界。

## 對現有 2,119 個錢包客戶的影響

- **不升級 = 零影響**（proxy 各自的 slot 不動，有測試釘住）
- passkey 2,115 人：**各一次**生物辨識（升級 UserOp 夾進下次登入／付款）；託管 4 人平台代簽靜默完成（DB 實測 `custodial=4`）
- 覆蓋率**永遠不到 100%** → 混合狀態是常態設計：worker 以 `supportsInterface(0x150b7a02)` 一次 eth_call 探測，V1 錢包 revert → 跳過不燒重試，升級完成的下一輪自動開始鑄卡，**離鏈側不需要再發版**
- gas 平台墊付（relayer 全額買單是現況），自營鏈成本趨近零
- 唯一重大風險：壞的新版實作會讓錢包**永久鎖死** → 部署順序強制 canary（ADR 021 Rollout 六步，每步可獨立回退）

#### Related Issues

- [X] Issue Number: 無（PR #6687 review 的阻擋級發現「`_safeMint` 對 SCW 必定 revert」的合約側解法；PR #6687 的離鏈側探針另行處理）

#### Checklist

- [x] Used `@` in import paths.（Solidity 檔以相對路徑 import vendored 函式庫，與既有合約一致）
- [x] Verified naming convention compliance.
- [x] Coding style verification: checked（jest 全套 227 suites / 3,022 tests 不受影響；`forge test` 12 條全綠）
- [x] new Library: 1 — foundry（僅 `forge test` 用；`foundry.toml` 開 `via_ir`，因 V1 factory 的 7 參數 emit 在 legacy codegen 會 stack too deep）
- [x] new Class / Component: 3（三個新合約）+ 1 個 forge 測試合約
- [x] new loop: 0
- [x] new recursive: 0
- [x] high risk: 1 — 合約程式碼本身。護欄：既有已部署合約零改動、本 PR 不部署任何東西、12 條 forge 測試含劫持路徑（initialize 不可重跑、anchor 不可初始化、升級限 EntryPoint、換實作限管理者）、三條關鍵不變式變異驗證會紅
- [x] new sql: 0

#### UML Diagrams

- None（部署順序見 ADR 021 Rollout）

#### Additional Notes

**變異驗證**：推導改綁實作 → 位址恆定測試紅（2 failing）；anchor 不自我升級 → 鑄卡測試紅（3 failing）；`initializer` 鎖拿掉 → 重跑 initialize 測試紅（1 failing）。

**部署前必查**（ADR 021 第 4 步）：切換 `NEXT_PUBLIC_SCW_FACTORY_ADDRESS` 前，逐一驗證所有 DB `user.address` 在鏈上都有 code；V1 factory 位址保留在設定中，既有使用者一律以 DB 位址為準，禁止重推。

**與 #6687 的關係**：本 PR 是「卡片鑄得出來」的前提；#6687 的 worker 會改用 `supportsInterface` 探針（跳過而非終局失敗），兩者可獨立合併、獨立部署。
