### PR TITLE
Fix/carbon chat input locality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isunfa",
-  "version": "0.12.0+221",
+  "version": "0.12.0+223",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/__tests__/chat_input_locality.test.ts
+++ b/src/__tests__/chat_input_locality.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/**
+ * Info: (20260827 - Emily) 打字只重渲染輸入框(#6718)。
+ *
+ * 這一條釘的是**架構**,不是行為 —— 而它必須是架構,因為讓打字變慢的不是
+ * 某個函式的邏輯錯誤,是 state 住錯地方:`inputValue` 原本住在
+ * `use_carbon_chat`(5700 行的 hook),而頁面整棵樹都消費那個 hook,
+ * 於是每一個按鍵都重渲染訊息列表 + 報告預覽(實測 59 頁、19 張表)+ 所有 mermaid 圖。
+ * 實測伴生「Mermaid rendering failed: Maximum update depth exceeded」。
+ *
+ * 沒有 jsdom 就量不到 render 次數(這個 repo 的 jest 是 node 環境),
+ * 所以判準取「state 的所在地」與「兩端的介面形狀」——
+ * 有人把文字搬回 hook、或把 `onInputChange` 那種每鍵回呼加回來,這條會紅。
+ */
+
+const ROOT = process.cwd();
+const read = (relative: string): string =>
+  fs.readFileSync(path.join(ROOT, relative), "utf-8");
+
+const CHAT_INPUT = "src/components/carbon_chatbot/chat_input.tsx";
+const HOOK = "src/hooks/use_carbon_chat.ts";
+const PAGE = "src/app/user/carbon_chatbot/page.tsx";
+
+describe("聊天輸入的 state 局部性(#6718)", () => {
+  it("文字住在 ChatInput 自己的 state 裡", () => {
+    const source = read(CHAT_INPUT);
+    expect(source).toContain("const [text, setText] = useState<string>");
+    expect(source).toContain("value={text}");
+    expect(source).toContain("onChange={(e) => setText(e.target.value)}");
+  });
+
+  it("ChatInput 不再收「每鍵回呼」與外部的完整文字", () => {
+    const source = read(CHAT_INPUT);
+    /**
+     * Info: (20260827 - Emily) 這兩個名字就是舊架構的形狀:
+     * `inputValue` = 文字從外面來(外面就得有 state);
+     * `onInputChange` = 每一鍵都往外呼叫(外面就得 setState)。
+     * 任一個回來,打字就會再次穿透到頁面層。
+     */
+    expect(source).not.toContain("onInputChange");
+    expect(source).not.toContain("inputValue");
+  });
+
+  it("hook 不再持有輸入文字的 state,只留下「下指令」的通道", () => {
+    const source = read(HOOK);
+    expect(source).not.toContain("const [inputValue, setInputValue]");
+    expect(source).toContain("const [inputPrefill, setInputPrefill]");
+    // Info: (20260827 - Emily) 預填以 nonce 觸發:值比對分不出「外部要求清空」與「使用者剛好刪空」
+    expect(source).toContain("nonce: prev.nonce + 1");
+  });
+
+  it("page 傳 prefill 而不是 inputValue/onInputChange", () => {
+    const source = read(PAGE);
+    expect(source).toContain("prefill={inputPrefill}");
+    expect(source).not.toContain("onInputChange=");
+    expect(source).not.toContain("inputValue={");
+  });
+
+  it("送出把文字上交(不靠外部去讀輸入框)", () => {
+    const source = read(CHAT_INPUT);
+    // Info: (20260827 - Emily) submit 先取值再清空,清空不等 async 的 onSendMessage 完成
+    expect(source).toContain("const outgoing = text;");
+    expect(source).toContain("onSendMessage(outgoing)");
+    expect(source).toContain("onSendMessage: (text: string) => void");
+  });
+
+  it("hook 的送出不再退回輸入框內容(它已經沒有那份 state)", () => {
+    const source = read(HOOK);
+    /**
+     * Info: (20260825 - Emily) 舊的型別硬化是「非字串退回 inputValue」——
+     * 那個退路在文字搬走之後不存在了。現在退成空字串,
+     * 由「無文字且無就緒附件即不送」的既有 guard 擋掉。
+     */
+    expect(source).toContain(
+      'typeof overrideText === "string" ? overrideText : ""',
+    );
+  });
+});

--- a/src/app/user/carbon_chatbot/page.tsx
+++ b/src/app/user/carbon_chatbot/page.tsx
@@ -59,8 +59,7 @@ export default function CarbonChatbotPage() {
     renameSession,
     renameReportDocument,
     updateReportIdentity,
-    inputValue,
-    setInputValue,
+    inputPrefill,
     isTyping,
     isLoading,
     isUnlocked,
@@ -297,10 +296,9 @@ export default function CarbonChatbotPage() {
               focusedMessageId={focusedMessageId}
             />
             <ChatInput
-              inputValue={inputValue}
+              prefill={inputPrefill}
               isTyping={isTyping}
               isLoading={isLoading}
-              onInputChange={setInputValue}
               onSendMessage={handleSendMessage}
               pendingAttachments={pendingAttachments}
               attachmentError={attachmentError}

--- a/src/components/carbon_chatbot/chat_input.tsx
+++ b/src/components/carbon_chatbot/chat_input.tsx
@@ -38,11 +38,28 @@ function ElapsedSince({ startedAt }: { startedAt: number }) {
 }
 
 export interface IChatInputProps {
-  inputValue: string;
+  /**
+   * Info: (20260827 - Emily) 輸入中的文字**住在本元件**(#6718)。
+   *
+   * 原本住在 `use_carbon_chat`(5700 行的 hook)的 state 裡,而頁面整棵樹都消費那個 hook ——
+   * 於是**每一個按鍵都重渲染整頁**:訊息列表 + 報告預覽(實測 59 頁、19 張表)
+   * + 所有 mermaid 圖。報告愈大每鍵愈貴,實測伴生
+   * 「Mermaid rendering failed: Maximum update depth exceeded」。
+   *
+   * 外部只剩兩種需求,各對應一個 prop:
+   * - **預填/清空**(跳段指引、切房、送出後)→ `prefill`(nonce 變動才覆寫)
+   * - **取得文字**(送出)→ `onSendMessage(text)` 把文字上交
+   * 打字因此完全不出這個元件。
+   */
+  prefill?: { value: string; nonce: number };
   isTyping: boolean;
   isLoading: boolean;
-  onInputChange: (value: string) => void;
-  onSendMessage: () => void;
+  /**
+   * Info: (20260827 - Emily) 送出時把當下文字上交(#6718)。
+   * `handleSendMessage(overrideText?)` 本來就支援帶文字進來
+   * (#6806 的「後續建議」按鈕就是這樣用),所以這裡不需要新機制。
+   */
+  onSendMessage: (text: string) => void;
   pendingAttachments?: IPendingAttachment[];
   attachmentError?: string | null;
   onAddFiles?: (files: File[]) => void;
@@ -87,10 +104,9 @@ export interface IChatInputProps {
 }
 
 export function ChatInput({
-  inputValue,
+  prefill = undefined,
   isTyping,
   isLoading,
-  onInputChange,
   onSendMessage,
   pendingAttachments = [],
   attachmentError = null,
@@ -111,6 +127,24 @@ export function ChatInput({
   const { t } = useTranslation();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isDragOver, setIsDragOver] = useState<boolean>(false);
+  /**
+   * Info: (20260827 - Emily) 輸入文字的所有者(#6718)。打字只重渲染本元件。
+   */
+  const [text, setText] = useState<string>(prefill?.value ?? "");
+  /**
+   * Info: (20260827 - Emily) 預填以 **nonce** 觸發,不以值比對:
+   * 「清空」的值是空字串,而使用者自己打字後又刪空也是空字串 ——
+   * 用值比對分不出「外部要求清空」與「使用者剛好刪空」,
+   * 後者會在每次 render 被覆寫回去(打字卡住的另一種形狀)。
+   * nonce 只在外部真的下指令時變動,所以 effect 只在那時跑。
+   */
+  const appliedPrefillRef = useRef<number | undefined>(prefill?.nonce);
+  useEffect(() => {
+    if (prefill === undefined) return;
+    if (appliedPrefillRef.current === prefill.nonce) return;
+    appliedPrefillRef.current = prefill.nonce;
+    setText(prefill.value);
+  }, [prefill]);
 
   const hasReadyAttachment = pendingAttachments.some(
     (a) => a.status === PendingAttachmentStatusEnum.READY,
@@ -121,14 +155,27 @@ export function ChatInput({
 
   // Info: (20260714 - Tzuhan) 有文字或有就緒附件即可送出;附件讀取中暫不可送,避免漏附件
   const disabled =
-    (!inputValue.trim() && !hasReadyAttachment) ||
+    (!text.trim() && !hasReadyAttachment) ||
     isTyping ||
     isLoading ||
     isReadingAttachment;
 
+  /**
+   * Info: (20260827 - Emily) 送出:把文字上交後**自己清空**(#6718)。
+   * 清空必須在這裡做 —— 文字的所有者是本元件,外部沒有它的 setter。
+   * 上交在清空之前:`onSendMessage` 是 async,清空不等它完成
+   * (等它完成才清,使用者會看到自己的字停在框裡好幾秒)。
+   */
+  const submit = () => {
+    if (disabled) return;
+    const outgoing = text;
+    setText("");
+    onSendMessage(outgoing);
+  };
+
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && !disabled) {
-      onSendMessage();
+      submit();
     }
   };
 
@@ -379,8 +426,8 @@ export function ChatInput({
 
         <input
           type="text"
-          value={inputValue}
-          onChange={(e) => onInputChange(e.target.value)}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
           onKeyDown={handleKeyDown}
           onDragOver={handleDragOver}
           onDragLeave={() => setIsDragOver(false)}
@@ -399,7 +446,7 @@ export function ChatInput({
            * 實測按鈕自此送不出任何訊息(只剩 Enter 可用),且每點一次
            * 一個 unhandledRejection。包一層丟棄事件參數。
            */
-          onClick={() => onSendMessage()}
+          onClick={submit}
           disabled={disabled}
           aria-label={t("carbon_chatbot.send_message")}
           className="absolute top-1/2 right-2 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-[#ff5a00] text-white shadow-sm transition-colors hover:bg-[#e04f00] disabled:cursor-not-allowed disabled:bg-gray-300"

--- a/src/hooks/use_carbon_chat.ts
+++ b/src/hooks/use_carbon_chat.ts
@@ -241,7 +241,26 @@ export const useCarbonChat = () => {
   >(() => createDefaultSessions());
   const [activeSessionId, setActiveSessionId] =
     useState<string>(DEFAULT_SESSION_ID);
-  const [inputValue, setInputValue] = useState<string>("");
+  /**
+   * Info: (20260827 - Emily) 輸入文字**不再住在這裡**(#6718)。
+   *
+   * 頁面整棵樹都消費這個 hook,所以文字放在這裡等於「每個按鍵重渲染整頁」——
+   * 訊息列表 + 報告預覽(實測 59 頁、19 張表)+ 所有 mermaid 圖都跟著重畫。
+   * 文字現在住在 `ChatInput`;這裡只保留**外部對輸入框下的指令**:
+   * 預填(跳段指引)與清空(切房、送出後)。
+   *
+   * 以 nonce 而非值來傳遞:清空的值是空字串,而使用者自己刪空也是空字串 ——
+   * 用值比對分不出「外部要求清空」與「剛好刪空」,後者會被每次 render 覆寫回去。
+   * nonce 只在真的下指令時 +1,所以 state 變動次數 = 指令次數(不是按鍵次數)。
+   */
+  const [inputPrefill, setInputPrefill] = useState<{
+    value: string;
+    nonce: number;
+  }>({ value: "", nonce: 0 });
+
+  const commandInput = useCallback((value: string) => {
+    setInputPrefill((prev) => ({ value, nonce: prev.nonce + 1 }));
+  }, []);
   // Info: (20260714 - Tzuhan) 等待 AI 回覆的 session 集合(per-session 隔離: 舊房等待中不影響新房輸入與指示)
   const [busySessionIds, setBusySessionIds] = useState<Set<string>>(new Set());
   const [isError, setIsError] = useState<boolean>(false);
@@ -1770,49 +1789,53 @@ export const useCarbonChat = () => {
 
   // Info: (20260714 - Tzuhan) 切換聊天室: 各室訊息/報告/等待狀態彼此隔離，僅重置跨室共用的暫態 UI
   // Info: (20260714 - Tzuhan) (輸入框、附件、高亮、跳段目標為輸入層暫態；busy/計時器 per-session 不需重置)
-  const switchSession = useCallback((sessionId: string) => {
-    setActiveSessionId(sessionId);
-    setActiveParagraphId(null);
-    setHighlightedParagraphId(null);
-    setFocusedMessageId(null);
-    setInputValue("");
-    setPendingAttachments([]);
-    setAttachmentError(null);
-    setSaveStatus(null);
-    setIsError(false);
-    /**
-     * Info: (20260811 - Emily) 這裡刻意**不再清除** draftNotice(#6624)。
-     *
-     * 這一行是 per-session 之前留下的:當時提示只有一格,「切房就清掉」本身就是隔離機制。
-     * 改成一房一格之後(20260806),隔離已由 `draftNoticeBySession[activeSessionId]` 完成,
-     * 這一行剩下的作用只有刪除 —— 而且刪的是**正要離開的那一房**:
-     * 省略 sessionId 的 `setDraftNotice` 讀 `activeSessionIdRef`,該 ref 由 effect 同步,
-     * 上一行的 `setActiveSessionId` 要到 commit 後才反映到 ref。
-     * 於是「A 房匯入中 → 切到 B 房」把 A 房的進度從 map 裡刪掉,
-     * 切回 A 房畫面是空的,要等下一次進度事件(可能好幾分鐘)才重新有字 ——
-     * 那正是 #6624 描述的「不會立刻出現」。
-     *
-     * 與下方 pendingImportBySession(20260805 - Luphia)同一個故事:
-     * 那次改了預覽卡,提示這一份漏了。
-     *
-     * 「匯入已結束才切回不得殘留假的進行中訊息」由匯入端保證:
-     * 每一條終止路徑都以 originSessionId 明確收尾
-     * (成功 `notify(null)`;失敗 `notify(error)` + `dismissDraftNoticeAfter`)。
-     */
-    setPendingRevision(null);
-    /**
-     * Info: (20260805 - Luphia) 這裡刻意**不動** pendingImportBySession。
-     * 它已經以發起匯入的會話 id 為鍵,切房本來就不需要重設任何東西 ——
-     * 而原本沿用「清掉唯一那筆」的舊語意去清空整個 map,恰好抵銷了 per-session 的全部意義:
-     * 在 A 房啟動匯入 → 切到 B 房等 → 匯入完成落成 { A: preview } → 點回 A 房
-     * → switchSession('A') 把 map 清成 {} → 預覽卡消失。
-     * 數分鐘的 LLM 工作與整份報告的配額靜默丟棄,連 retryFailedImportChapters 都救不回來
-     * (它需要 pendingImport)。
-     *
-     * 生命週期正確的清除點是「會話消失」而不是「切走」,故改在 archiveSession 移除該鍵。
-     */
-    pendingDraftParagraphIdRef.current = null;
-  }, []);
+  const switchSession = useCallback(
+    (sessionId: string) => {
+      setActiveSessionId(sessionId);
+      setActiveParagraphId(null);
+      setHighlightedParagraphId(null);
+      setFocusedMessageId(null);
+      // Info: (20260827 - Emily) #6718:切房清空輸入框(文字在 ChatInput,經 nonce 下指令)
+      commandInput("");
+      setPendingAttachments([]);
+      setAttachmentError(null);
+      setSaveStatus(null);
+      setIsError(false);
+      /**
+       * Info: (20260811 - Emily) 這裡刻意**不再清除** draftNotice(#6624)。
+       *
+       * 這一行是 per-session 之前留下的:當時提示只有一格,「切房就清掉」本身就是隔離機制。
+       * 改成一房一格之後(20260806),隔離已由 `draftNoticeBySession[activeSessionId]` 完成,
+       * 這一行剩下的作用只有刪除 —— 而且刪的是**正要離開的那一房**:
+       * 省略 sessionId 的 `setDraftNotice` 讀 `activeSessionIdRef`,該 ref 由 effect 同步,
+       * 上一行的 `setActiveSessionId` 要到 commit 後才反映到 ref。
+       * 於是「A 房匯入中 → 切到 B 房」把 A 房的進度從 map 裡刪掉,
+       * 切回 A 房畫面是空的,要等下一次進度事件(可能好幾分鐘)才重新有字 ——
+       * 那正是 #6624 描述的「不會立刻出現」。
+       *
+       * 與下方 pendingImportBySession(20260805 - Luphia)同一個故事:
+       * 那次改了預覽卡,提示這一份漏了。
+       *
+       * 「匯入已結束才切回不得殘留假的進行中訊息」由匯入端保證:
+       * 每一條終止路徑都以 originSessionId 明確收尾
+       * (成功 `notify(null)`;失敗 `notify(error)` + `dismissDraftNoticeAfter`)。
+       */
+      setPendingRevision(null);
+      /**
+       * Info: (20260805 - Luphia) 這裡刻意**不動** pendingImportBySession。
+       * 它已經以發起匯入的會話 id 為鍵,切房本來就不需要重設任何東西 ——
+       * 而原本沿用「清掉唯一那筆」的舊語意去清空整個 map,恰好抵銷了 per-session 的全部意義:
+       * 在 A 房啟動匯入 → 切到 B 房等 → 匯入完成落成 { A: preview } → 點回 A 房
+       * → switchSession('A') 把 map 清成 {} → 預覽卡消失。
+       * 數分鐘的 LLM 工作與整份報告的配額靜默丟棄,連 retryFailedImportChapters 都救不回來
+       * (它需要 pendingImport)。
+       *
+       * 生命週期正確的清除點是「會話消失」而不是「切走」,故改在 archiveSession 移除該鍵。
+       */
+      pendingDraftParagraphIdRef.current = null;
+    },
+    [commandInput],
+  );
 
   // Info: (20260716 - Tzuhan) 對話改名:設自訂旗標(首訊衍生不再覆蓋);sessions 索引 effect 自動持久化
   const renameSession = useCallback((sessionId: string, title: string) => {
@@ -4473,13 +4496,14 @@ export const useCarbonChat = () => {
         return { ...prev, [activeSessionId]: updatedSession };
       });
 
-      setInputValue(
+      // Info: (20260827 - Emily) #6718:跳段預填(同上,經 nonce 下指令)
+      commandInput(
         t("carbon_chatbot.jump_prompt", {
           section: `${section.code} ${section.title}`,
         }),
       );
     },
-    [activeSessionId, t],
+    [activeSessionId, commandInput, t],
   );
 
   // Info: (20260714 - Tzuhan) 反向連動: 點報告段落 → 捲動至最近一則關聯訊息並閃爍；無關聯訊息則 fallback 為跳段引導
@@ -5108,8 +5132,14 @@ export const useCarbonChat = () => {
        * `.trim` 直接炸,而且是 unhandledRejection(按鈕壞了卻沒有紅字)。
        * 非字串一律退回輸入框內容:錯誤呼叫降級成正常送出,不是靜默壞死。
        */
-      const outgoingText =
-        typeof overrideText === "string" ? overrideText : inputValue;
+      /**
+       * Info: (20260827 - Emily) #6718:文字一律由呼叫端帶進來
+       * (ChatInput 送出時上交、後續建議按鈕帶按鈕上的字)。
+       * hook 這裡不再有 `inputValue` 可退 —— 非字串時退成空字串,
+       * 下面「無文字且無就緒附件即不送」的既有 guard 會擋掉,
+       * 也就是錯誤呼叫降級成「不送出」而不是拿到 MouseEvent 去 `.trim`。
+       */
+      const outgoingText = typeof overrideText === "string" ? overrideText : "";
       const readyAttachments = pendingAttachments.filter(
         (a) => a.status === PendingAttachmentStatusEnum.READY,
       );
@@ -5185,7 +5215,13 @@ export const useCarbonChat = () => {
         return { ...prev, [activeSessionId]: updatedSession };
       });
 
-      setInputValue("");
+      /**
+       * Info: (20260827 - Emily) #6718:送出後清空。
+       * `ChatInput` 送出時已自行清空(它是文字的所有者),這裡再下一次指令
+       * 是為了**非輸入框發起的送出**(後續建議按鈕、跳段後自動送出)——
+       * 那些路徑不經過元件的 submit,框裡的字不會自己消失。
+       */
+      commandInput("");
       setPendingAttachments([]);
       setAttachmentError(null);
       markSessionBusy(activeSessionId, true);
@@ -5419,7 +5455,7 @@ export const useCarbonChat = () => {
     },
     [
       payExistingOrder,
-      inputValue,
+      commandInput,
       isLoading,
       pendingAttachments,
       activeSession,
@@ -5613,8 +5649,7 @@ export const useCarbonChat = () => {
     renameSession,
     renameReportDocument,
     updateReportIdentity,
-    inputValue,
-    setInputValue,
+    inputPrefill,
     isTyping,
     isLoading,
     isError,


### PR DESCRIPTION
# PR:輸入文字搬進輸入框 —— 打字不再重渲染整頁(#6718)
 
**標題建議**:`fix(carbon): 輸入文字搬進輸入框 —— 打字不再重渲染整頁(#6718)`
 
**分支**:`fix/carbon_chat_input_locality` → base `develop`(無前置依賴)
**版號**:`0.12.0+223`(develop `+221`;`+222` 為 #6725、`+224` 已被其他分支占用,已全掃確認)
 
---
 
## 問題不是邏輯錯誤,是 state 住錯地方
 
`inputValue` 原本住在 `use_carbon_chat`(5700 行的 hook),而頁面整棵樹都消費那個 hook
—— 於是**每一個按鍵都重渲染整頁**:訊息列表 + 報告預覽(實測 59 頁、19 張表)
+ 所有 mermaid 圖。報告愈大,每一鍵愈貴。
實測伴生症狀(08-25 的 log):快速打字的渲染風暴讓圖表元件的巢狀更新撞到 React 上限,
`Mermaid rendering failed: Maximum update depth exceeded`。
而問答功能(#6707)上線後「匯入完成後在同一個房間打字」變成主要使用情境,
這個成本因此從邊緣移到日常路徑上。
 
## 改動
 
| 檔 | 改了什麼 |
|---|---|
| `chat_input.tsx` | 文字改為本元件 state(`text`);打字只重渲染輸入框 |
| `chat_input.tsx` | 送出改為**把文字上交**:`onSendMessage(text)`,並自行清空 |
| `use_carbon_chat.ts` | `inputValue` state → `inputPrefill: {value, nonce}`,以 `commandInput()` 下指令 |
| `page.tsx` | 傳 `prefill={inputPrefill}`,移除 `inputValue` / `onInputChange` |
 
**送出不需要新機制**:`handleSendMessage(overrideText?)` 本來就支援帶文字進來
(08-06 的「後續建議」按鈕就是這樣用的),元件只是改成走同一條路。
submit **先取值再清空**,清空不等 async 的送出完成 ——
等它完成才清,使用者會看到自己的字停在框裡好幾秒。
 
**預填以 nonce 而非值傳遞**(這是本 PR 唯一值得爭論的設計選擇):
「清空」的值是空字串,而使用者自己刪空也是空字串 ——
用值比對分不出「外部要求清空」與「使用者剛好刪空」,後者會在每次 render 被覆寫回去,
那是打字卡住的另一種形狀。nonce 只在外部真的下指令時 +1,
所以 hook 的 state 變動次數 = **指令次數**(切房、跳段預填、非輸入框發起的送出),
不是按鍵次數。
 
**送出的型別硬化保留**:非字串參數(08-25 那次把 `handleSendMessage` 直接綁 `onClick`,
MouseEvent 進到 `overrideText` → `.trim` 炸掉)現在退成空字串,
由「無文字且無就緒附件即不送」的既有 guard 擋掉 —— 錯誤呼叫降級成「不送出」。
 
## 測試:釘架構,不是釘行為(附理由)
 
新增 `src/__tests__/chat_input_locality.test.ts`(6 條)。
 
這個 repo 的 jest 是 **node 環境、沒有 jsdom**,量不到 render 次數 ——
所以自動測試能守的是「state 的所在地」與「兩端的介面形狀」:
- 文字必須在元件自己的 `useState` 裡,textarea 綁本地值
- `inputValue` / `onInputChange` 這兩個**舊架構的名字不得回來**
  (前者 = 文字從外面來 → 外面就得有 state;後者 = 每鍵往外呼叫 → 外面就得 setState;
   任一個回來,打字就會再次穿透到頁面層)
- hook 不得再持有那份 state,只留 nonce 通道
- page 必須傳 `prefill`
- 送出必須把文字上交,而 hook 的非字串退路必須是空字串
全套 `npm test`:**4627 passed**;`npm run typecheck` 0 error;`npm run lint` 無新增警告。
 
## 人工驗收(自動測試證明不了效能,請 reviewer 一起看)
 
- [ ] 匯入完成的房間(59 頁報告)連續打 50 字,無可感延遲
- [ ] React DevTools Profiler:按鍵事件不再觸發報告預覽 / 訊息列表的 render
- [ ] 快速打字下不再出現 mermaid `Maximum update depth exceeded`
- [ ] 既有行為不變:Enter 送出、按鈕送出、跳段預填、切房清空、送出後清空、
      後續建議按鈕(它帶自己的文字,不經輸入框)
## 高風險欄(照實填)
 
輸入框是**每一次對話的入口**:文字的所有者換了地方,壞掉的形狀是「打不了字」或
「送出的內容不對」,而且會影響所有碳盤查對話。
自動測試守得住架構不被改回去,守不住「畫面上還能不能打字」——
所以上面那份人工驗收不是形式,是這個 PR 的主要證據。
先前這條路徑上已經有過一次「送出鈕自綁 handler」的事故(08-25),
本 PR 保留了那次的型別硬化,並在測試裡釘住退路的語意。
 
## 票務
 
併入後關:#6718。

#### Checklist

- [x] Used `@` in import paths.
- [x] Verified naming convention compliance ([Naming Convention Guidelines](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md)).
- [x] Coding style verification: checked
- [x] new Library: 0
- [x] new Class / Component: 0
- [x] new loop: 0
- [x] new recursive: 0
- [x] high risk: 0
- [x] new sql: 0

#### UML Diagrams

- None

#### Additional Notes

- Ensured all links are up-to-date.
- Conducted thorough testing on responsive design changes.
- Documented any notable considerations or edge cases addressed.